### PR TITLE
Non-WCAG rule: ARIA state/property has valid value

### DIFF
--- a/_rules/SC4-1-2-aria-state-or-property-has-valid-value.md
+++ b/_rules/SC4-1-2-aria-state-or-property-has-valid-value.md
@@ -24,7 +24,7 @@ authors:
 Any [non-empty](#non-empty) [WAI-ARIA 1.1 state or property](https://www.w3.org/TR/wai-aria-1.1/#state_prop_def) that 
 - is specified on an HTML or SVG element
 - is one of the `aria-*` attributes included in the [accessible name computation](https://www.w3.org/TR/accname-1.1/#mapping_additional_nd_te), or is specified on an element that is [included in the accessibility tree](#included-in-the-accessibility-tree) or is [focusable](#focusable),
-- is not the empty string ("").
+- is not empty ("").
 
 ### Expectation 1
 

--- a/_rules/SC4-1-2-aria-state-or-property-has-valid-value.md
+++ b/_rules/SC4-1-2-aria-state-or-property-has-valid-value.md
@@ -3,10 +3,10 @@ name: ARIA state or property has valid value
 rule_type: atomic
 
 description: |
-   This rule checks that each ARIA state or property has a valid value
+   This rule checks that each WAI-ARIA state or property has a valid value
    
 success_criterion:
-- 4.1.2 # Name, Role, Value
+- (WAI-ARIA 1.1)
 
 test_aspects:
 - DOM Tree
@@ -21,26 +21,24 @@ authors:
 
 ### Applicability
 
-Any [non-empty](#non-empty) [WAI-ARIA 1.1 state or property](https://www.w3.org/TR/wai-aria-1.1/#state_prop_def) that is specified on an HTML or SVG element.
+Any [non-empty](#non-empty) [WAI-ARIA 1.1 state or property](https://www.w3.org/TR/wai-aria-1.1/#state_prop_def) that 
+- is specified on an HTML or SVG element
+- is one of the `aria-*` attributes included in the [accessible name computation](https://www.w3.org/TR/accname-1.1/#mapping_additional_nd_te), or is specified on an element that is [included in the accessibility tree](#included-in-the-accessibility-tree) or is [focusable](#focusable),
+- is not the empty string ("").
 
 ### Expectation 1
 
 Each test target has a valid value according to its [WAI-ARIA 1.1 value type](https://www.w3.org/TR/wai-aria-1.1/#propcharacteristic_value).
 
-For value types `ID Reference` and `ID Reference List` for [WAI-ARIA required properties](https://www.w3.org/TR/wai-aria-1.1/#requiredState) at least one of the elements with the given ids exists in the same [document tree](https://www.w3.org/TR/dom41/#document-trees) or [shadow tree](https://www.w3.org/TR/dom41/#shadow-trees) as the element that specifies the target attribute. 
-
 For value type `URI` the value matches the [generic URI syntax](https://www.ietf.org/rfc/rfc3986.txt).
 
-**Note:** Only for [WAI-ARIA required properties](https://www.w3.org/TR/wai-aria-1.1/#requiredState) with value types `ID Reference` and `ID Reference List` is there a requirement that the elements with the given ids actually exists. For non-required properties, this is not a requirement.
+**Note:** For value type `URI`, this rule does not require that the destination URI exists. 
 
-**Note:** 
-For value type `URI`, this rule does not require that the destination URI exists. 
+**Note:** For value type `ID Reference` and `ID Reference List`, this rule does not require the elements with the given ids to actually exist in the same [document tree](https://www.w3.org/TR/dom41/#document-trees) or [shadow tree](https://www.w3.org/TR/dom41/#shadow-trees) as the element that specifies the target attribute. 
 
 ## Assumptions
 
-- This rule assumes that elements that are not [included in the accessibility tree](#included-in-the-accessibility-tree) or are [focusable](#focusable) can still impact users. Therefore the applicability of this rule is not limited to [WAI-ARIA 1.1 states and properties](https://www.w3.org/TR/wai-aria-1.1/#state_prop_def) on elements that are included in the accessibility tree or are focusable.
-**Note:**  For example, anything referenced through `aria-labelledby` does not have to be [included in the accessibility tree](#included-in-the-accessibility-tree) in order for it to become part of the [accessible name](#accessible-name).
-- The ARIA `state` or `property` is being used to comply to WCAG.
+- This rule assumes that elements that are not [included in the accessibility tree](#included-in-the-accessibility-tree) or are [focusable](#focusable) can still impact users if they are used for the [accessible name computation](https://www.w3.org/TR/accname-1.1/#mapping_additional_nd_te). Therefore the applicability of this rule also includes `aria-*` attributes that participate in the accessible name computation as well as [WAI-ARIA 1.1 states and properties](https://www.w3.org/TR/wai-aria-1.1/#state_prop_def) that are specified on elements that are included in the accessibility tree or are focusable.
 
 ## Accessibility Support
 


### PR DESCRIPTION
This is now a WAI-ARIA validation rule. 
It does not refer to any WCAG success criterion, but to WAI-ARIA 1.1 as its accessibility requirement (the Auto-WCAG template does not allow this, however).

Builds on issues:
- #376 (Is it possible to limit the applicability of "ARIA state or property has valid value"?)
- #365 (Update Rule: ARIA state or property has valid value)

# How to Review And Approve
- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines. 
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
