### PR TITLE
chore: add unique id to all rules

### DIFF
--- a/_rules/SC1-1-1-accessible-name-is-image-filename.md
+++ b/_rules/SC1-1-1-accessible-name-is-image-filename.md
@@ -1,15 +1,13 @@
 ---
+id: 9eb3f6
 name: Filename is valid accessible name
 description: |
   This rule checks that image elements that use their source filename as their accessible name do so without loss of information to the user.
-
 success_criterion:
 - 1.1.1 # Non-Text Content
-
 test_aspects:
 - DOM Tree
 - CSS Styling
-
 authors:
 - Bryn Anderson
 ---

--- a/_rules/SC1-1-1-image-has-name.md
+++ b/_rules/SC1-1-1-image-has-name.md
@@ -1,15 +1,13 @@
 ---
+id: 23a2a8
 name: Image has accessible name
 description: |
   Each image that is not marked as decorative, has an accessible name
-
 success_criterion:
   - 1.1.1 # Non-Text Content
-
 test_aspects:
   - DOM Tree
   - CSS Styling
-
 authors:
   - Anne Thyme Nørregaard
   - Stein Erik Skotkjerra

--- a/_rules/SC1-2-1-audio-only-alternative.md
+++ b/_rules/SC1-2-1-audio-only-alternative.md
@@ -1,4 +1,5 @@
 ---
+id: e7aa44
 name: audio only has a text alternative
 rule_type: composite
 description: |

--- a/_rules/SC1-2-1-audio-transcript.md
+++ b/_rules/SC1-2-1-audio-transcript.md
@@ -1,16 +1,13 @@
 ---
+id: 2eb176
 name: audio elements have a transcript
-
 rule_type: atomic
-
 description: |
   Non-streaming `audio` elements must have a text alternative for all included auditory information.
-
 test_aspects:
   - DOM Tree
   - CSS Styling
   - Audio output
-
 authors:
   - Wilco Fiers
   - Brian Bors

--- a/_rules/SC1-2-1-media-alternative-audio.md
+++ b/_rules/SC1-2-1-media-alternative-audio.md
@@ -1,16 +1,13 @@
 ---
+id: afb423
 name: Audio-only as a media alternative for text
-
 rule_type: atomic
-
 description: |
   This rule checks `audio` is a media alternative for text on the page.
-
 test_aspects:
   - DOM Tree
   - CSS Styling
   - Audio output
-
 authors:
   - Wilco Fiers
   - Brian Bors

--- a/_rules/SC1-2-1-media-alternative-video.md
+++ b/_rules/SC1-2-1-media-alternative-video.md
@@ -1,16 +1,13 @@
 ---
+id: fd26cf
 name: Video-only as a media alternative for text
-
 rule_type: atomic
-
 description: |
   This rule checks non-streaming silent `video` is a media alternative for text on the page.
-
 test_aspects:
   - DOM Tree
   - CSS Styling
   - Audio output
-
 authors:
   - Wilco Fiers
   - Brian Bors

--- a/_rules/SC1-2-1-video-only-alternative.md
+++ b/_rules/SC1-2-1-video-only-alternative.md
@@ -1,18 +1,16 @@
 ---
+id: c3232f
 name: video only has an accessibile alternative
 rule_type: composite
 description: |
   This rule checks if video elements without audio have an alternative available
-
 success_criterion:
   - 1.2.1 # Audio-only and Video-only (Prerecorded)
-
 atomic_rules:
   - SC1-2-1-media-alternative-video
   - SC1-2-1-video-only-description-track
   - SC1-2-1-video-only-element-transcript
   - SC1-2-1-video-only-audio-alternative
-
 authors:
   - Wilco Fiers
   - Brian Bors

--- a/_rules/SC1-2-1-video-only-audio-alternative.md
+++ b/_rules/SC1-2-1-video-only-audio-alternative.md
@@ -1,15 +1,14 @@
 ---
+id: d7ba54
 name: video only has audio alternative
 rule_type: atomic
 description: |
   Non-streaming `video` elements without audio must have an audio alternative
-
 test_aspects:
   - DOM Tree
   - CSS Styling
   - Audio output
   - Visual output
-
 authors:
   - Brian Bors
 ---

--- a/_rules/SC1-2-1-video-only-description-track.md
+++ b/_rules/SC1-2-1-video-only-description-track.md
@@ -1,15 +1,14 @@
 ---
+id: ac7dc6
 name: Video only element has description track
 rule_type: atomic
 description: |
   This rule checks that description tracks that come with non-streaming `video` elements, without audio, are descriptive.
-
 test_aspects:
   - DOM Tree
   - CSS Styling
   - Audio output
   - Visual output
-
 authors:
   - Wilco Fiers
   - Brian Bors

--- a/_rules/SC1-2-1-video-only-element-transcript.md
+++ b/_rules/SC1-2-1-video-only-element-transcript.md
@@ -1,15 +1,14 @@
 ---
+id: ee13b5
 name: video only element has transcript
 rule_type: atomic
 description: |
   Non-streaming `video` elements without audio must have all visual information available in a transcript.
-
 test_aspects:
   - DOM Tree
   - CSS Styling
   - Audio output
   - Visual output
-
 authors:
   - Wilco Fiers
   - Brian Bors

--- a/_rules/SC1-2-2-video-has-audio-alternative.md
+++ b/_rules/SC1-2-2-video-has-audio-alternative.md
@@ -1,18 +1,14 @@
 ---
+id: eac66b
 name: Video has audio alternative
-
 rule_type: atomic
-
 description: |
   This rule checks that video elements have an alternative for information conveyed through audio
-
 success_criterion:
   - 1.2.2
-
 atomic_rules:
   - SC1-2-video-media-alternative
   - SC1-2-2-video-has-captions
-
 authors:
   - Wilco Fiers
   - Brian Bors

--- a/_rules/SC1-2-2-video-has-captions.md
+++ b/_rules/SC1-2-2-video-has-captions.md
@@ -1,17 +1,15 @@
 ---
+id: f51b46
 name: video has captions
 description: |
   Captions are available for audio information in non-streaming `video` elements.
-
 success_criterion:
   - 1.2.2 # Captions (Prerecorded)
-
 test_aspects:
   - DOM Tree
   - CSS Styling
   - Audio output
   - Visual output
-
 authors:
   - Wilco Fiers
   - Brian Bors

--- a/_rules/SC1-2-3-video-alternative.md
+++ b/_rules/SC1-2-3-video-alternative.md
@@ -1,18 +1,16 @@
 ---
+id: c5a4ea
 name: video with audio has audio descriptions or transcript
 rule_type: composite
 description: |
   This rule checks video elements with audio have an alternative for the video content as audio or as text.
-
 success_criterion:
   - 1.2.3 # Audio Description or Media Alternative (Prerecorded)
-
 atomic_rules:
   - SC1-2-video-audio-description
   - SC1-2-video-transcript
   - SC1-2-video-description-track
   - SC1-2-video-media-alternative
-
 authors:
   - Wilco Fiers
   - Brian Bors

--- a/_rules/SC1-2-5-video-audio-alternative.md
+++ b/_rules/SC1-2-5-video-audio-alternative.md
@@ -1,17 +1,15 @@
 ---
+id: 1ec09b
 name: video with audio has audio description
 rule_type: composite
 description: |
   This rule checks video elements with audio have audio description
-
 success_criterion:
   - 1.2.5 # Audio Description (Prerecorded)§
-
 atomic_rules:
   - SC1-2-video-audio-description
   - SC1-2-video-media-alternative
   - SC1-2-video-description-track
-
 authors:
   - Wilco Fiers
   - Brian Bors

--- a/_rules/SC1-2-video-audio-description.md
+++ b/_rules/SC1-2-video-audio-description.md
@@ -1,15 +1,14 @@
 ---
+id: 1ea59c
 name: video element audio described
 rule_type: atomic
 description: |
   Non-streaming `video` elements must have all visual information also contained in the audio
-
 test_aspects:
   - DOM Tree
   - CSS Styling
   - Audio output
   - Visual output
-
 authors:
   - Wilco Fiers
   - Brian Bors

--- a/_rules/SC1-2-video-description-track.md
+++ b/_rules/SC1-2-video-description-track.md
@@ -1,15 +1,14 @@
 ---
+id: f196ce
 name: Video element description track
 rule_type: atomic
 description: |
   This rule checks that description tracks that come with non-streaming `video` elements are descriptive.
-
 test_aspects:
   - DOM Tree
   - CSS Styling
   - Audio output
   - Visual output
-
 authors:
   - Wilco Fiers
   - Brian Bors

--- a/_rules/SC1-2-video-media-alternative.md
+++ b/_rules/SC1-2-video-media-alternative.md
@@ -1,14 +1,13 @@
 ---
+id: ab4d13
 name: Video as a media alternative for text
 rule_type: atomic
 description: |
   This rule checks non-streaming `video` is a media alternative for text on the page.
-
 test_aspects:
   - DOM Tree
   - CSS Styling
   - Audio output
-
 authors:
   - Wilco Fiers
   - Brian Bors

--- a/_rules/SC1-2-video-transcript.md
+++ b/_rules/SC1-2-video-transcript.md
@@ -1,18 +1,16 @@
 ---
+id: 1a02b0
 name: video element transcript
 rule_type: atomic
 description: |
   Non-streaming `video` elements must have all audio and visual information available in a transcript.
-
 success_criterion:
   - 1.2.8 # Media Alternative (Prerecorded)
-
 test_aspects:
   - DOM Tree
   - CSS Styling
   - Audio output
   - Visual output
-
 authors:
   - Wilco Fiers
   - Brian Bors

--- a/_rules/SC1-3-1-aria-hidden-focus.md
+++ b/_rules/SC1-3-1-aria-hidden-focus.md
@@ -1,18 +1,15 @@
 ---
+id: 6cfa84
 name: aria-hidden with focusable content
 rule_type: atomic
-
 description: |
   This rule checks that elements with an `aria-hidden` attribute do not contain focusable elements
-
 success_criterion:
 - 1.3.1 # Info and Relationships
 - 4.1.2 # Name, Role, Value
-
 test_aspects:
   - DOM Tree
   - CSS Styling
-
 authors:
   - Wilco Fiers
 ---

--- a/_rules/SC1-3-5-autocomplete-valid.md
+++ b/_rules/SC1-3-5-autocomplete-valid.md
@@ -1,15 +1,13 @@
 ---
+id: 73f2c2
 name: Autocomplete valid
 description: |
   This rule checks that the HTML autocomplete attribute has a correct value
-
 success_criterion:
   - 1.3.5 # Identify Input Purpose
-
 test_aspects:
   - DOM Tree
   - CSS Styling
-
 authors:
   - Wilco Fiers
 ---

--- a/_rules/SC2-1-2-no-keyboard-trap-non-standard-navigation.md
+++ b/_rules/SC2-1-2-no-keyboard-trap-non-standard-navigation.md
@@ -1,14 +1,12 @@
 ---
+id: ebe86a
 name: No keyboard trap non-standard navigation
 rule_type: atomic
-
 description: |
   This rule checks if it is possible to use non-standard keyboard navigation to navigate through content where focus is trapped when using standard ways of keyboard navigation.
-
 test_aspects:
   - DOM Tree
   - CSS Styling
-
 authors:
   - Dagfinn Rømen
   - Geir Sindre Fossøy

--- a/_rules/SC2-1-2-no-keyboard-trap-standard-navigation.md
+++ b/_rules/SC2-1-2-no-keyboard-trap-standard-navigation.md
@@ -1,14 +1,12 @@
 ---
+id: a1b64e
 name: No keyboard trap standard navigation
 rule_type: atomic
-
 description: |
   This rule checks if it is possible to use standard keyboard navigation to navigate through all content on a web page without becoming trapped in any element.
-
 test_aspects:
   - DOM Tree
   - CSS Styling
-
 authors:
   - Dagfinn Rømen
   - Geir Sindre Fossøy

--- a/_rules/SC2-1-2-no-keyboard-trap.md
+++ b/_rules/SC2-1-2-no-keyboard-trap.md
@@ -1,17 +1,14 @@
 ---
+id: 80af7b
 name: No keyboard trap
 rule_type: composite
-
 description: |
   This rule checks for keyboard traps. This includes use of both standard and non-standard keyboard navigation to navigate through all content without becoming trapped.
-
 success_criterion:
   - 2.1.2 # No Keyboard Trap
-
 atomic_rules:
   - SC2-1-2-no-keyboard-trap-standard-navigation
   - SC2-1-2-no-keyboard-trap-non-standard-navigation
-
 authors:
   - Geir Sindre Fossøy
   - Dagfinn Rømen

--- a/_rules/SC2-2-1+SC2-2-4-meta-refresh.md
+++ b/_rules/SC2-2-1+SC2-2-4-meta-refresh.md
@@ -1,16 +1,14 @@
 ---
+id: bc659a
 name: Meta-refresh no delay
 description: |
   This rule checks that the meta element is not used for delayed redirecting or refreshing.
-
 success_criterion:
   - 2.2.1 # Timing Adjustable
   - 2.2.4 # Interruptions
   - 3.2.5 # Change on Request
-
 test_aspects:
   - DOM Tree
-
 authors:
   - Anne Thyme Nørregaard
   - Wilco Fiers

--- a/_rules/SC2-4-2-page-has-title.md
+++ b/_rules/SC2-4-2-page-has-title.md
@@ -1,15 +1,12 @@
 ---
+id: 2779a5
 name: HTML Page has a title
-
 description: |
   This rule checks that the HTML page has a title
-
 success_criterion:
   - 2.4.2 # Page Titled
-
 test_aspects:
   - DOM Tree
-
 authors:
   - Wilco Fiers
   - Stein Erik Skotkjerra

--- a/_rules/SC2-4-4+2-4-9+4-1-2-link-has-name.md
+++ b/_rules/SC2-4-4+2-4-9+4-1-2-link-has-name.md
@@ -1,17 +1,15 @@
 ---
+id: c487ae
 name: Links have an accessible name
 description: |
   Each link has an accessible name
-
 success_criterion:
   - 4.1.2 # Name, Role, Value
   - 2.4.4 # Link Purpose (In Context)
   - 2.4.9 # Link Purpose (Link Only)
-
 test_aspects: # Remove what is not applicable
   - DOM Tree
   - CSS Styling
-
 authors:
   - Wilco Fiers
   - Anne Thyme Nørregaard

--- a/_rules/SC2-4-6-descriptive-headings.md
+++ b/_rules/SC2-4-6-descriptive-headings.md
@@ -1,17 +1,14 @@
 ---
+id: b49b2e
 name: Heading is descriptive
 rule_type: atomic
-
 description: |
   This rule checks that headings describe the topic or purpose of the content.
-
 success_criterion:
   - 2.4.6 # Headings and labels
-
 test_aspects:
   - DOM Tree
   - CSS Styling
-
 authors:
   - Dagfinn Rømen
   - Geir Sindre Fossøy

--- a/_rules/SC2-4-6-descriptive-labels.md
+++ b/_rules/SC2-4-6-descriptive-labels.md
@@ -1,17 +1,14 @@
 ---
+id: cc0f0a
 name: Form field label is descriptive
 rule_type: atomic
-
 description: |
   This rule checks that labels describe the purpose of form field elements.
-
 success_criterion:
   - 2.4.6 # Headings and labels
-
 test_aspects:
   - DOM Tree
   - CSS Styling
-
 authors:
   - Dagfinn Rømen
   - Geir Sindre Fossøy

--- a/_rules/SC2-5-3-label-content-name-mismatch.md
+++ b/_rules/SC2-5-3-label-content-name-mismatch.md
@@ -1,15 +1,13 @@
 ---
+id: 2ee8b8
 name: label and name from content mismatch
 description: |
   Interactive elements labelled through their content must have their visible label as part of their accessible name
-
 success_criterion:
   - 2.5.3 # Label in Name
-
 test_aspects:
   - DOM Tree
   - CSS Styling
-
 authors:
   - Anne Thyme Nørregaard
   - Bryn Anderson

--- a/_rules/SC3-1-1-html-has-lang.md
+++ b/_rules/SC3-1-1-html-has-lang.md
@@ -1,17 +1,13 @@
 ---
+id: b5c3f8
 name: HTML has lang attribute
-
 rule_type: atomic
-
 description: |
   This rule checks that the `html` element has a non-empty `lang` or `xml:lang` attribute.
-
 success_criterion:
   - 3.1.1
-
 test_aspects:
   - DOM Tree
-
 authors:
   - Annika Nietzio
   - Jey Nandakumar

--- a/_rules/SC3-1-1-html-lang-valid.md
+++ b/_rules/SC3-1-1-html-lang-valid.md
@@ -1,15 +1,12 @@
 ---
+id: bf051a
 name: Validity of HTML Lang attribute
-
 description: |
   This rule checks the lang or xml:lang attribute has a valid language subtag.
-
 success_criterion:
   - 3.1.1
-
 test_aspects:
   - DOM Tree
-
 authors:
   - Annika Nietzio
   - Jey Nandakumar

--- a/_rules/SC3-1-1-html-xml-lang-match.md
+++ b/_rules/SC3-1-1-html-xml-lang-match.md
@@ -1,15 +1,12 @@
 ---
+id: 5b7ae0
 name: HTML lang and xml:lang match
-
 description: |
   The rule checks that for the `html` element, there is no mismatch between the primary language in non-empty `lang` and `xml:lang` attributes, if both are used.
-
 success_criterion:
   - 3.1.1
-
 test_aspects:
   - DOM Tree # The tree that HTML is parsed into.
-
 authors:
   - Annika Nietzio
   - Jey Nandakumar

--- a/_rules/SC3-1-2-lang-valid.md
+++ b/_rules/SC3-1-2-lang-valid.md
@@ -1,15 +1,12 @@
 ---
+id: de46e4
 name: Valid body lang attribute
-
 description: |
   This rule checks that `lang` or `xml:lang` attributes on elements within the `body` of a web page have a valid language subtag.
-
 success_criterion:
   - 3.1.2
-
 test_aspects:
   - DOM Tree
-
 authors:
   - Bryn Anderson
   - Jey Nandakumar

--- a/_rules/SC4-1-1-unique-attrs.md
+++ b/_rules/SC4-1-1-unique-attrs.md
@@ -1,15 +1,13 @@
 ---
+id: e6952f
 name: attributes are not duplicated
 rule_type: atomic
 description: |
   This rule checks that HTML and SVG starting tags do not contain duplicated attributes.
-
 success_criterion:
   - 4.1.1 # Parsing
-
 test_aspects:
   - Source code
-
 authors:
   - Wilco Fiers
   - Emma Pratt Richens

--- a/_rules/SC4-1-1-unique-id.md
+++ b/_rules/SC4-1-1-unique-id.md
@@ -1,16 +1,13 @@
 ---
+id: 3ea0c8
 name: Id attribute is unique
 rule_type: atomic
-
 description: |
   This rule checks that all `id` attribute values on a single page are unique.
-
 success_criterion:
   - 4.1.1 # Success Criterion 4.1.1 (Parsing)
-
 test_aspects:
   - DOM Tree
-
 authors:
   - Bryn Anderson
   - Anne Thyme

--- a/_rules/SC4-1-2-aria-attr-valid.md
+++ b/_rules/SC4-1-2-aria-attr-valid.md
@@ -1,15 +1,12 @@
 ---
+id: 5f99a7
 name: ARIA attribute is valid
-
 description: |
   This rule checks that each aria- attribute specified is defined in ARIA 1.1
-
 success_criterion:
   - 4.1.2
-
 test_aspects:
   - DOM Tree
-
 authors:
   - Jey Nandakumar
 ---

--- a/_rules/SC4-1-2-aria-state-or-property-allowed.md
+++ b/_rules/SC4-1-2-aria-state-or-property-allowed.md
@@ -1,14 +1,12 @@
 ---
+id: 5c01ea
 name: ARIA state or property allowed
 description: |
   This rule checks that WAI-ARIA states or properties are allowed for the element they are specified on.
-
 success_criterion:
   - 4.1.2 # Name, Role, Value (A)
-
 test_aspects:
   - DOM Tree
-
 authors:
   - Anne Thyme Nørregaard
 ---

--- a/_rules/SC4-1-2-aria-state-or-property-has-valid-value.md
+++ b/_rules/SC4-1-2-aria-state-or-property-has-valid-value.md
@@ -1,17 +1,14 @@
 ---
+id: 6a7281
 name: ARIA state or property has valid value
 rule_type: atomic
-
 description: |
   This rule checks that each ARIA state or property has a valid value
-
 success_criterion:
   - 4.1.2 # Name, Role, Value
-
 test_aspects:
   - DOM Tree
   - CSS Styling
-
 authors:
   - Wilco Fiers
   - Anne Thyme Nørregaard

--- a/_rules/SC4-1-2-button-has-name.md
+++ b/_rules/SC4-1-2-button-has-name.md
@@ -1,16 +1,13 @@
 ---
+id: 97a4e1
 name: Buttons have an accessible name
-
 description: |
   Each button element has an accessible name
-
 success_criterion:
   - 4.1.2
-
 test_aspects:
   - DOM Tree
   - CSS Styling
-
 authors:
   - Wilco Fiers
   - Stein Erik Skotkjerra

--- a/_rules/SC4-1-2-form-field-has-name.md
+++ b/_rules/SC4-1-2-form-field-has-name.md
@@ -1,14 +1,12 @@
 ---
+id: e086e5
 name: Form field has accessible name
 description: |
   Each form field element has an accessible name
-
 success_criterion:
   - 4.1.2 # Name, Role, Value
-
 test_aspects:
   - DOM Tree
-
 authors:
   - Anne Thyme Nørregaard
   - Bryn Anderson

--- a/_rules/SC4-1-2-iframe-has-name.md
+++ b/_rules/SC4-1-2-iframe-has-name.md
@@ -1,16 +1,13 @@
 ---
+id: cae760
 name: iframe has an accessible name
-
 description: |
   Each iframe element has an accessible name
-
 success_criterion:
   - 4.1.2 # Name, Role, Value (A)
-
 test_aspects:
   - DOM Tree
   - CSS Styling
-
 authors:
   - Jey Nandakumar
 ---

--- a/_rules/SC4-1-2-role-attribute-has-valid-value.md
+++ b/_rules/SC4-1-2-role-attribute-has-valid-value.md
@@ -1,17 +1,14 @@
 ---
+id: 674b10
 name: Role attribute has valid value
 rule_type: atomic
-
 description: |
   This rule checks that each role attribute has a valid value
-
 success_criterion:
   - 4.1.2 # Name, Role, Value
-
 test_aspects:
   - DOM Tree
   - CSS Styling
-
 authors:
   - Jey Nandakumar
 ---

--- a/_rules/SC4-1-2-role-has-required-states-and-properties.md
+++ b/_rules/SC4-1-2-role-has-required-states-and-properties.md
@@ -1,14 +1,12 @@
 ---
+id: 4e8ab6
 name: Role has required states and properties
 description: |
   Elements that have an explicit role must also specify all required states and properties
-
 success_criterion:
   - 4.1.2 # Name, Role, Value
-
 test_aspects:
   - DOM Tree
-
 authors:
   - Anne Thyme Nørregaard
 ---

--- a/_rules/image-button-has-name.md
+++ b/_rules/image-button-has-name.md
@@ -1,17 +1,15 @@
 ---
+id: 59796f
 name: Image button has accessible name
 rule_type: atomic
 description: |
   This rule checks that each image button element has an accessible name 
-
 success_criterion:
   - 1.1.1 # Non-Text Content (A)
   - 4.1.2 # Name, Role, Value (A)
-
 test_aspects: # Remove what is not applicable
   - DOM Tree
   - CSS Styling
-
 authors:
   - Anne Thyme Nørregaard
 ---

--- a/gatsby/get-node-data.js
+++ b/gatsby/get-node-data.js
@@ -1,5 +1,6 @@
+const fs = require('fs')
+const fm = require('fastmatter')
 const { createFilePath } = require('gatsby-source-filesystem')
-const customId = require('custom-id')
 
 /**
  * Get node data, to enhance metadata of pages
@@ -9,7 +10,7 @@ const customId = require('custom-id')
 const getNodeData = options => {
 	const { node, getNode } = options
 	const fileNode = getNode(node.parent)
-	const { sourceInstanceName, relativePath } = fileNode
+	const { sourceInstanceName, relativePath, absolutePath } = fileNode
 
 	const defaults = {
 		sourceInstanceName: sourceInstanceName,
@@ -19,10 +20,13 @@ const getNodeData = options => {
 
 	switch (sourceInstanceName) {
 		case 'rules':
-			const hash = customId({ name: relativePath })
+			const fileContents = fs.readFileSync(absolutePath, { encoding: 'utf-8' })
+			const { attributes } = fm(fileContents)
+			const { id } = attributes
+			console.log(id);
 			return {
 				...defaults,
-				path: `${sourceInstanceName}/${hash}`,
+				path: `${sourceInstanceName}/${id}`,
 			}
 		default:
 			return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3796,14 +3796,6 @@
 				"array-find-index": "^1.0.1"
 			}
 		},
-		"custom-id": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/custom-id/-/custom-id-1.2.0.tgz",
-			"integrity": "sha512-lL59dGGzd5cYL6Z1NPlPo0Lze5t3JcWKOiaLupGhYUxpPWa5ZduL5rEggBWU4JT29wM429UgYIiY89qzL7iMmQ==",
-			"requires": {
-				"math-random": "^1.0.4"
-			}
-		},
 		"cwebp-bin": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/cwebp-bin/-/cwebp-bin-5.0.0.tgz",
@@ -5380,6 +5372,27 @@
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+		},
+		"fastmatter": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/fastmatter/-/fastmatter-2.1.1.tgz",
+			"integrity": "sha512-NFrjZEPJZTexoJEuyM5J7n4uFaLf0dOI7Ok4b2IZXOYBqCp1Bh5RskANmQ2TuDsz3M35B1yL2AP/Rn+kp85KeA==",
+			"requires": {
+				"js-yaml": "^3.13.0",
+				"split": "^1.0.1",
+				"stream-combiner": "^0.2.2",
+				"through2": "^3.0.1"
+			},
+			"dependencies": {
+				"through2": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+					"integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+					"requires": {
+						"readable-stream": "2 || 3"
+					}
+				}
+			}
 		},
 		"fastparse": {
 			"version": "1.1.2",
@@ -9408,11 +9421,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.2.tgz",
 			"integrity": "sha512-NcWuJFHDA8V3wkDgR/j4+gZx+YQwstPgfQDV8ndUeWWzta3dnDTBxpVzqS9lkmJAuV5YX35lmyojl6HO5JXAgw=="
-		},
-		"math-random": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
-			"integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A=="
 		},
 		"md5": {
 			"version": "2.2.1",
@@ -13778,6 +13786,14 @@
 				}
 			}
 		},
+		"split": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+			"requires": {
+				"through": "2"
+			}
+		},
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -13922,6 +13938,15 @@
 			"requires": {
 				"inherits": "~2.0.1",
 				"readable-stream": "^2.0.2"
+			}
+		},
+		"stream-combiner": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+			"integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
+			"requires": {
+				"duplexer": "~0.1.1",
+				"through": "~2.3.4"
 			}
 		},
 		"stream-each": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 	],
 	"dependencies": {
 		"axios": "^0.18.0",
-		"custom-id": "^1.2.0",
+		"fastmatter": "^2.1.1",
 		"gatsby": "^2.3.21",
 		"gatsby-image": "^2.0.30",
 		"gatsby-plugin-manifest": "^2.0.20",

--- a/package.json
+++ b/package.json
@@ -116,19 +116,19 @@
 		"get-wcag-sc-metadata": "node ./build/get-wcag-sc-metadata",
 		"get-data": "npm run get-wcag-sc-metadata && npm run get-implementations"
 	},
-	"homepage": "https://github.com/auto-wcag/auto-wcag#readme",
+	"homepage": "https://github.com/act-rules/act-rules.github.io",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/auto-wcag/auto-wcag.git"
+		"url": "https://github.com/act-rules/act-rules.github.io"
 	},
 	"bugs": {
-		"url": "https://github.com/gatsbyjs/gatsby/issues"
+		"url": "https://github.com/act-rules/act-rules.github.io/issues"
 	},
 	"pulls": {
-		"url": "https://github.com/auto-wcag/auto-wcag/pulls"
+		"url": "https://github.com/act-rules/act-rules.github.io/pulls"
 	},
 	"www": {
-		"url": "//auto-wcag.github.io/auto-wcag",
+		"url": "https://act-rules.github.io",
 		"baseDir": "./public"
 	},
 	"config": {


### PR DESCRIPTION
Adding a hexadecimal unique id as a part of the frontmatter of all rules, and using the same to generate urls of rule pages in the website.

Closes issue: 
- https://github.com/act-rules/act-rules.github.io/issues/470
- https://github.com/act-rules/act-rules.github.io/issues/476#issuecomment-483225977

Some screenshots:
![image](https://user-images.githubusercontent.com/20978252/56199257-750f1780-6034-11e9-937c-061632c9dba2.png)

![image](https://user-images.githubusercontent.com/20978252/56199134-3711f380-6034-11e9-8596-f351f01598ce.png)

![image](https://user-images.githubusercontent.com/20978252/56199174-4a24c380-6034-11e9-92d2-f11be9a97042.png)
