### PR TITLE
chore: update test case names  to be hash and not have outcome

### DIFF
--- a/gatsby/create-page-generate-testcases.js
+++ b/gatsby/create-page-generate-testcases.js
@@ -6,6 +6,7 @@
  */
 
 const { ncp } = require('ncp')
+const objectHash = require('object-hash')
 const codeBlocks = require('gfm-code-blocks')
 const {
 	www: { url, baseDir },
@@ -61,21 +62,23 @@ const createPageGenerateTestcases = options => {
 					throw new Error('No title found for code snippet.')
 				}
 
-				const { code } = codeBlock
+				const { code, block } = codeBlock
 				let { type = 'html' } = codeBlock
 
-				if (
-					regexps.testcaseCodeSnippetTypeIsSvg.test(
-						codeBlock.block.substring(0, 15)
-					)
-				) {
+				if (regexps.testcaseCodeSnippetTypeIsSvg.test(block.substring(0, 15))) {
 					type = 'svg'
 				}
 
-				const uniqueId = slug.replace('rules/', '')
+				const ruleId = slug.replace('rules/', '')
+				const codeId = objectHash({
+					block,
+					type,
+					ruleId
+				})
+
 				const titleCurated = title.value.split(' ').map(t => t.toLowerCase())
 
-				const testcaseFileName = `${uniqueId}-${titleCurated.join('-')}.${type}`
+				const testcaseFileName = `${ruleId}-${codeId}.${type}`
 				const testcasePath = `testcases/${testcaseFileName}`
 				/**
 				 * Create testcase file
@@ -88,7 +91,7 @@ const createPageGenerateTestcases = options => {
 				const testcase = {
 					url: `${url}/${testcasePath}`,
 					expected: titleCurated[0],
-					ruleId: uniqueId,
+					ruleId,
 					ruleName: name,
 					rulePage: `${url}/${slug}`,
 				}

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
 		"ncp": "^2.0.0",
 		"node-sass": "^4.11.0",
 		"normalize.css": "^8.0.1",
+		"object-hash": "^1.3.1",
 		"prismjs": "^1.16.0",
 		"prop-types": "^15.7.2",
 		"react": "^16.8.6",


### PR DESCRIPTION
**Note: As this is chore, it will be merged this with out approvals**

This change makes a test case file name to not have outcome as a part of it.
The hash generated is unique to the contents of the testcase codeblock & will only change if the contents of the test case is changed.

Previously:
```
"testcases": [
    {
      "url": "https://act-rules.github.io/testcases/5f99a7-passed-example-1.html",
      "expected": "passed",
      "ruleId": "5f99a7",
      "ruleName": "ARIA attribute is valid",
      "rulePage": "https://act-rules.github.io/rules/5f99a7"
    },
	...
]
```

After this change:
```
 "testcases": [
    {
      "url": "https://act-rules.github.io/testcases/5f99a7-55f3ed0ec0f324514a0d223b737bc1e4c81593c7.html",
      "expected": "passed",
      "ruleId": "5f99a7",
      "ruleName": "ARIA attribute is valid",
      "rulePage": "https://act-rules.github.io/rules/5f99a7"
    },
    ...
]
```

Closes Issue: https://github.com/act-rules/act-rules.github.io/issues/484