### PR TITLE
chore: fix invalid frontmatter in updated templates

### DIFF
--- a/_rules/html-lang-valid-bf051a.md
+++ b/_rules/html-lang-valid-bf051a.md
@@ -5,7 +5,7 @@ rule_type: atomic
 description: |
   This rule checks the lang or xml:lang attribute has a valid language subtag.
 accessibility_requirements:
-  wcag20:3.1.1: Language of Page (A)
+  wcag20:3.1.1: # Language of Page (A)
     forConformance: true
     failed: not satisfied
     passed: further testing needed

--- a/_rules/unique-id-3ea0c8.md
+++ b/_rules/unique-id-3ea0c8.md
@@ -5,7 +5,7 @@ rule_type: atomic
 description: |
   This rule checks that all `id` attribute values on a single page are unique.
 accessibility_requirements:
-  wcag20:4.1.1: Parsing (A)
+  wcag20:4.1.1: # Parsing (A)
     forConformance: true
     failed: not satisfied
     passed: further testing needed


### PR DESCRIPTION
Noticed some invalid `frontmatter` along with the template updates. 
This PR has the fixes for the same.