### PR TITLE
chore: fix frontmatter for atomic rules enumeration

### DIFF
--- a/_rules/audio-only-text-alternative-e7aa44.md
+++ b/_rules/audio-only-text-alternative-e7aa44.md
@@ -10,7 +10,7 @@ accessibility_requirements:
     failed: not satisfied
     passed: further testing needed
     inapplicable: further testing needed
-input_rules:
+atomic_rules:
   - audio-have-transcript-2eb176
   - audio-as-media-alternative-afb423
 authors:

--- a/_rules/video-alternative-c5a4ea.md
+++ b/_rules/video-alternative-c5a4ea.md
@@ -10,7 +10,7 @@ accessibility_requirements:
     failed: not satisfied
     passed: further testing needed
     inapplicable: further testing needed
-input_rules:
+atomic_rules:
   - video-audio-described-1ea59c
   - video-transcript-1a02b0
   - video-description-track-f196ce

--- a/_rules/video-audio-alternative-1ec09b.md
+++ b/_rules/video-audio-alternative-1ec09b.md
@@ -10,7 +10,7 @@ accessibility_requirements:
     failed: not satisfied
     passed: further testing needed
     inapplicable: further testing needed
-input_rules:
+atomic_rules:
   - video-audio-described-1ea59c
   - video-media-alternative-ab4d13
   - video-description-track-f196ce

--- a/_rules/video-has-audio-alternative-eac66b.md
+++ b/_rules/video-has-audio-alternative-eac66b.md
@@ -10,7 +10,7 @@ accessibility_requirements:
     failed: not satisfied
     passed: further testing needed
     inapplicable: further testing needed
-input_rules:
+atomic_rules:
   - video-media-alternative-ab4d13
   - video-has-captions-f51b46
 authors:


### PR DESCRIPTION
Some keys were wrong as a part of the template updation.