### PR TITLE
chore: add missing contributors

### DIFF
--- a/_rules/audio-only-text-alternative-e7aa44.md
+++ b/_rules/audio-only-text-alternative-e7aa44.md
@@ -17,7 +17,7 @@ authors:
   - Wilco Fiers
   - Brian Bors
   - John Hicks
-  - Rafal Charlampozicz
+  - Rafal Charlampowicz
 ---
 
 ## Applicability

--- a/_rules/document-title-is-descriptive-c4a8a4.md
+++ b/_rules/document-title-is-descriptive-c4a8a4.md
@@ -14,7 +14,7 @@ input_aspects:
   - DOM Tree
 authors:
   - Anne Thyme Nørregaard
-  - Corbb O’Connor
+  - Corbb O'Connor
 ---
 
 ## Applicability

--- a/_rules/no-keyboard-trap-80af7b.md
+++ b/_rules/no-keyboard-trap-80af7b.md
@@ -15,8 +15,8 @@ input_rules:
   - ebe86a
 authors:
   - Geir Sindre Fossøy
-    - Dagfinn Rømen
-    - Anne Thyme Nørregaard
+  - Dagfinn Rømen
+  - Anne Thyme Nørregaard
 ---
 
 ## Applicability

--- a/_rules/unique-id-3ea0c8.md
+++ b/_rules/unique-id-3ea0c8.md
@@ -14,7 +14,7 @@ input_aspects:
   - DOM Tree
 authors:
   - Bryn Anderson
-  - Anne Thyme
+  - Anne Thyme Nørregaard
 ---
 
 ## Applicability

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
 			"url": "https://github.com/annethyme"
 		},
 		{
+			"name": "Annika Nietzio",
+			"url": "https://github.com/annika-FTB"
+		},
+		{
 			"name": "Audrey Maniez",
 			"url": "https://github.com/audreymaniez"
 		},
@@ -49,8 +53,16 @@
 			"url": "https://github.com/jkodu"
 		},
 		{
+			"name": "John Hicks",
+			"url": "https://github.com/john-urbilog"
+		},
+		{
 			"name": "Malin Øvrebø",
 			"url": "https: //github.com/MaliinO"
+		},
+		{
+			"name": "Rafal Charlampowicz",
+			"url": "https://github.com/Rafalchar"
 		},
 		{
 			"name": "Rob Fentress",
@@ -152,8 +164,11 @@
 	},
 	"jest": {
 		"verbose": true,
+		"bail": true,
 		"testPathIgnorePatterns": [
-			"<rootDir>/test/utils/"
+			"<rootDir>/test/utils/",
+			"<rootDir>/.cache/",
+			"<rootDir>/.public/"
 		]
 	}
 }

--- a/test/rule-frontmatter.test.js
+++ b/test/rule-frontmatter.test.js
@@ -1,9 +1,11 @@
 
 const describeRule = require('./utils/describe-rule')
+const { contributors } = require('./../package.json')
+const contributorsNames = contributors.map(contributor => contributor.name.toLowerCase())
 
 describeRule('frontmatter', (ruleData) => {
   const { frontmatter } = ruleData
-  const { rule_type } = frontmatter
+  const { rule_type, authors } = frontmatter
 
   /**
    * Check for `required` properties
@@ -36,4 +38,12 @@ describeRule('frontmatter', (ruleData) => {
       expect(frontmatter).not.toHaveProperty('input_rules');
     })
   }
+  
+  /**
+   * Check if listed `authors` have meta data as contributors in package.json
+   */
+  test.each(authors)('has contributor data for author: `%s`',
+    (author) => {
+      expect(contributorsNames).toContain(author.toLowerCase());
+    })
 })


### PR DESCRIPTION
This PR does the below:
- add missing `contributors` to `package.json`.
- add tests for validating if listed authors exist as `contributors`.

Closes issue: 
- Partially closes https://github.com/act-rules/act-rules.github.io/issues/472
