### PR TITLE
chore: add accessibility requirements to test cases (json)

### DIFF
--- a/gatsby/create-testcases-of-all-rules.js
+++ b/gatsby/create-testcases-of-all-rules.js
@@ -101,6 +101,7 @@ const createTestcasesOfAllRules = options => {
 					ruleId,
 					ruleName,
 					rulePage: `${url}/${slug}`,
+					ruleAccessibilityRequirements
 				}
 
 				out.push(testcase)


### PR DESCRIPTION
This PR adds the accessibility requirements to test cases. This is useful for auto mapping of test cases against rules to validate against in test engines.

![image](https://user-images.githubusercontent.com/20978252/59218772-e98bb000-8bb8-11e9-970d-4cedcbe5c3a7.png)
