### PR TITLE
Fix: Rule  9eb3f6 - fix passed test case 2 

### DIFF
--- a/_rules/filename-is-accessible-name-9eb3f6.md
+++ b/_rules/filename-is-accessible-name-9eb3f6.md
@@ -55,9 +55,9 @@ The `img` element's accessible name uses the filename which accurately describes
 The `img` element's accessible name uses the filename, which in combination with the `a` element accurately describes the image.
 
 ```html
-<a href="https://www.w3.org/WAI/demos/bad/img/w3c.png" download
-	>Download <img src="https://www.w3.org/WAI/demos/bad/img/w3c/w3c.png" alt="w3c.png"
-/></a>
+<a href="https://www.w3.org/WAI/demos/bad/img/w3c.png" download >
+	Download <img src="https://www.w3.org/WAI/demos/bad/img/w3c.png" alt="w3c.png"/>
+</a>
 ```
 
 ### Failed

--- a/_rules/filename-is-accessible-name-9eb3f6.md
+++ b/_rules/filename-is-accessible-name-9eb3f6.md
@@ -56,7 +56,7 @@ The `img` element's accessible name uses the filename, which in combination with
 
 ```html
 <a href="https://www.w3.org/WAI/demos/bad/img/w3c.png" download
-	>Download <img src="w3c.png" alt="w3c.png"
+	>Download <img src="https://www.w3.org/WAI/demos/bad/img/w3c/w3c.png" alt="w3c.png"
 /></a>
 ```
 


### PR DESCRIPTION
Change the src of the image on the passed example 2 so the image is rendered when playing the example preview in separate html page.

Rule in question: https://act-rules.github.io/rules/9eb3f6


Closes issue: NA