### PR TITLE
fix: broken links across site

### DIFF
--- a/pages/about.md
+++ b/pages/about.md
@@ -22,9 +22,9 @@ The ACT Rules Community Group is a group of accessibility tool vendors, test pro
 
 The ACTR Community is an open community, meaning that anyone with an interest in our work is welcome to participate. The ACTR Community has three resources that are important to know about. Github, the community group page, and the ACTR Community website.
 
-- [ACTR Website](https://auto-wcag.github.io/auto-wcag) The ACTR Community website is where all the work is published. If you are interested to learn what rules have been agreed upon by the group, and who has implemented those, this is the place to go.
+- [ACTR Website](https://act-rules.github.io/) The ACTR Community website is where all the work is published. If you are interested to learn what rules have been agreed upon by the group, and who has implemented those, this is the place to go.
 
-- [Github](https://github.com/auto-wcag/auto-wcag) All work in the community group happens on Github. To participate you will need a Github account and basic familiarity with Github. If you are new to Github, there are several great articles and video's on the web explaining the basics of Github. Here are a few:
+- [Github](https://github.com/act-rules/act-rules.github.io) All work in the community group happens on Github. To participate you will need a Github account and basic familiarity with Github. If you are new to Github, there are several great articles and video's on the web explaining the basics of Github. Here are a few:
 
   - http://www.madebyloren.com/posts/github-for-writers
   - https://www.youtube.com/watch?v=9XhbYHcaT9k&t=7s

--- a/pages/contribute.md
+++ b/pages/contribute.md
@@ -30,7 +30,7 @@ If you want to get even more out of your involvement in our rule creation projec
 
 ## Give feedback on rules
 
-Feedback on rules is encouraged on our open [Github repository]({{site.data.package.repository.url}}), so you don't even have to be a member of the Community Group to contribute in this way.
+Feedback on rules is encouraged on our open [Github repository](https://github.com/act-rules/act-rules.github.io), so you don't even have to be a member of the Community Group to contribute in this way.
 
 If you "watch" the repository, you will get notifications when changes are happening.
 
@@ -44,9 +44,9 @@ Please feel free to add your own comments to issues.
 
 Start giving feedback on issues:
 
-- See the [ideas and early drafts that might need input]({{site.data.package.bugs.url}})
+- See the [ideas and early drafts that might need input](https://github.com/act-rules/act-rules.github.io/issues)
 
-- Use the [Definition of "Done"](../pages/design/definition-of-done.html) to guide your review
+- Use the [Definition of "Done"](../design/definition-of-done) to guide your review
 - Learn more about [commenting on issues](#) (TBD)
 
 ### Feedback and reviews for draft rules (Pull Requests on Github)
@@ -55,14 +55,14 @@ Pull requests are rule drafts that are ready for peer reviews. You can sign up a
 
 You can both add single comments to a pull request and do a full review.
 
-**Only approve a rule** if you feel confident (to the best of your knowledge) that this rule is 100% ready to be a published ACT rule. Please also refer to the [Definition of "Done"](../pages/design/definition-of-done.html).
+**Only approve a rule** if you feel confident (to the best of your knowledge) that this rule is 100% ready to be a published ACT rule. Please also refer to the [Definition of "Done"](../design/definition-of-done).
 
 If you for some reason are not so confident, you can always leave a comment for the things that you have an opinion about, without doing a full review.
 
 Start giving feedback and doing reviews for draft rules:
 
-- See the [draft rules, algorithms and more that need more reviewers]({{site.data.package.pulls.url}}?q=is%3Aopen+is%3Apr+label%3A%22reviewer+wanted%22)
-- Use the [Definition of "Done"](../pages/design/definition-of-done.html) to guide your review
+- See the [draft rules, algorithms and more that need more reviewers](https://github.com/act-rules/act-rules.github.io/pulls?q=is%3Aopen+is%3Apr+label%3A%22reviewer+wanted%22)
+- Use the [Definition of "Done"](../design/definition-of-done) to guide your review
 - Learn more about [reviewing and commenting on pull requests](#) (TBD)
 
 ### Feedback/corrections for published rules
@@ -73,12 +73,12 @@ Feedback and corrections for existing rules can target both on the sections of t
 
 You have several options for correcting existing rules:
 
-- **Open a discussion in an Issue:** If you want to open a discussion, you can [open a new issue on Github]({{site.data.package.bugs.url}}) repository to discuss the issue with the existing rule. Learn more about [creating issues](#) (TBD).
-- **Make the change yourself in a pull request:** If you know exactly what you want changed, you can do the change yourself as a [pull request on Github]({{site.data.package.pulls.url}}) and submit it for review. Learn more about [creating pull requests](#) (TBD).
+- **Open a discussion in an Issue:** If you want to open a discussion, you can [open a new issue on Github](https://github.com/act-rules/act-rules.github.io/issues) repository to discuss the issue with the existing rule. Learn more about [creating issues](#) (TBD).
+- **Make the change yourself in a pull request:** If you know exactly what you want changed, you can do the change yourself as a [pull request on Github](https://github.com/act-rules/act-rules.github.io/pulls) and submit it for review. Learn more about [creating pull requests](#) (TBD).
 
 ## Suggest new rules
 
-Anyone can suggest new rules on our open [Github repository]({{site.data.package.repository.url}}), so you don't even have to be a member of the Community Group to contribute in this way.
+Anyone can suggest new rules on our open [Github repository](https://github.com/act-rules/act-rules.github.io), so you don't even have to be a member of the Community Group to contribute in this way.
 
 Whether you have a single great idea for an accessibility rule or you work for an organisation that wants to contribute a whole repository of rules, we welcome the contribution.
 
@@ -92,13 +92,13 @@ Depending on how polished your rule proposal is, you can either add your idea as
 
 ### Submit an idea for discussion (Issue on Github)
 
-For rule contributors with less Github experience, it is often easiest to start the rule design in a [Github issue]({{site.data.package.bugs.url}}). This allows for easy editing and discussions with others, while the rule is taking shape.
+For rule contributors with less Github experience, it is often easiest to start the rule design in a [Github issue](https://github.com/act-rules/act-rules.github.io/issues). This allows for easy editing and discussions with others, while the rule is taking shape.
 
 [Learn more about how we work in Github issues](#) (TBD).
 
 ### Submit a draft for a rule (Pull Request on Github)
 
-If you have a ready rule draft, you can submit it as a [pull request]({{site.data.package.pulls.url}}) to go into the [review process](#) (TBD).
+If you have a ready rule draft, you can submit it as a [pull request](https://github.com/act-rules/act-rules.github.io/pulls) to go into the [review process](#) (TBD).
 
 Before contributing a new rule, we recommend you check its validity with several experienced accessibility auditors first. This helps you identify potential stumbling blocks early in the rule design.
 


### PR DESCRIPTION
Some of the links were using `jekyll` liquid interpolation & have not been updated since migrating to `gatsby`.

Closes issue: 
- https://github.com/act-rules/act-rules.github.io/issues/608
