### PR TITLE
fix: ACT format full compliance

### DIFF
--- a/pages/glossary/outcome.md
+++ b/pages/glossary/outcome.md
@@ -1,0 +1,14 @@
+---
+title: Outcome
+key: outcome
+---
+
+A conclusion that comes from evaluating an ACT Rule on a [test subject](https://www.w3.org/TR/act-rules-format/#test-subject) or one of its constituent [test target](https://www.w3.org/TR/act-rules-format/#test-target). An outcome can be one of the three following types:
+
+- **Inapplicable:** No part of the test subject matches the applicability
+- **Passed:** A [test target](https://www.w3.org/TR/act-rules-format/#test-target) meets all expectations
+- **Failed:** A [test target](https://www.w3.org/TR/act-rules-format/#test-target) does not meet all expectations
+
+**Note:** A rule has one `passed` or `failed` outcome for every [test target](https://www.w3.org/TR/act-rules-format/#test-target). When there are no test targets the rule has one `inapplicable` outcome. This means that each [test subject](https://www.w3.org/TR/act-rules-format/#test-subject) will have one or more outcomes.
+
+**Note:** Implementers using the [EARL10-Schema](https://www.w3.org/TR/EARL10-Schema/) can express the outcome with the [outcome property](https://www.w3.org/TR/EARL10-Schema/#outcome). In addition to `passed`, `failed` and `inapplicable`, EARL 1.0 also defined an `incomplete` outcome. While this cannot be the outcome of an ACT Rule when applied in its entirety, it often happens that rules are only partially evaluated. For example, when applicability was automated, but the expectations have to be evaluated manually. Such "interim" results can be expressed with the `incomplete` outcome.

--- a/src/templates/rule.js
+++ b/src/templates/rule.js
@@ -14,6 +14,7 @@ import {
 	getInputAspects,
 	getImplementations,
 	getImplementationsLink,
+	getDateTimeFromUnixTimestamp,
 } from './../utils/render-fragments'
 import SEO from '../components/seo'
 import { contributors, repository, config } from './../../package.json'
@@ -45,6 +46,14 @@ export default ({ data }) => {
 					{/* frontmatter */}
 					<ul className="meta">
 						{getRuleType(frontmatter.rule_type)}
+						<li>
+							<span className="heading">Rule ID:</span>
+							<span> {ruleId}</span>
+						</li>
+						<li>
+							<span className="heading">Last modified:</span>
+							<span> {getDateTimeFromUnixTimestamp(ruleChangelog[0].date)}</span>
+						</li>
 						<li>{getAccessibilityRequirements(accessibility_requirements)}</li>
 						<li>
 							{getInputAspects(
@@ -83,6 +92,28 @@ export default ({ data }) => {
 						repository.url,
 						`_rules/${relativePath}`
 					)}
+					{/* Useful links */}
+					<a href="#useful-links" id="useful-links">
+						<h2>Useful Links</h2>
+					</a>
+					<ul>
+						<li>
+							<a
+								target="_blank"
+								rel="noopener noreferrer"
+								href={issuesUrl}
+							>
+								Github issues related to this rule
+							</a>
+						</li>
+						<li>
+							<a target="_blank"
+								rel="noopener noreferrer"
+								href={ruleTestcasesUrl} >
+								Test case file for use in the WCAG-EM Report Tool
+							</a>
+						</li>
+					</ul>
 					<hr />
 					{/* implementations */}
 					{getImplementations(slug)}
@@ -107,38 +138,16 @@ export default ({ data }) => {
 						{getGlossaryUsedLink(slug, allGlossary)}
 						{/* changelog */}
 						{getChangelogLink(ruleChangelog)}
+						<li>
+							<a href="#useful-links">Useful Links</a>
+						</li>
 						{/* implementations */}
 						{getImplementationsLink(slug)}
 						<li>
 							<a href="#acknowledgements">Acknowledgements</a>
 						</li>
-					</ul>
-					{/* todo:jey needs fixing up */}
-					<span role="heading" aria-level="1" className="heading">
-						Useful Links
-					</span>
-					<ul>
 						<li>
-							<a
-								className="btn-secondary"
-								aria-label="test cases of rule for use in wcag em report tool"
-								target="_blank"
-								rel="noopener noreferrer"
-								href={issuesUrl}
-							>
-								View Issues
-							</a>
-						</li>
-						<li>
-							<a
-								className="btn-secondary"
-								aria-label="test cases of rule for use in wcag em report tool"
-								target="_blank"
-								rel="noopener noreferrer"
-								href={ruleTestcasesUrl}
-							>
-								Testcases (EM Report Tool)
-							</a>
+							<a href="#acknowledgements">Acknowledgements</a>
 						</li>
 					</ul>
 				</div>

--- a/src/utils/render-fragments.js
+++ b/src/utils/render-fragments.js
@@ -167,8 +167,9 @@ export const getChangelogLink = changelog => {
 
 export const getGlossaryUsed = (slug, allGlossary) => {
 	const usedKeys = getGlossaryItemsUsedInRule(slug)
-	if (!usedKeys) {
-		return null
+	// Always show the outcome definition:
+	if (!usedKeys.includes('#outcome')) {
+		usedKeys.push('#outcome')
 	}
 	const glossaries = allGlossary.edges.filter(({ node }) => {
 		const {
@@ -243,7 +244,7 @@ export function getRuleType(rule_type) {
 	return (
 		<li>
 			<span className="heading">Rule Type</span>
-			<p>{rule_type}</p>
+			<span>{rule_type}</span>
 		</li>
 	)
 }
@@ -255,15 +256,14 @@ export function getAccessibilityRequirements(
 	if (!accessibility_requirements) {
 		return (
 			<div className="meta">
-				<span className="heading">accessibility Requirements</span>
+				<span className="heading">Accessibility Requirements Mapping</span>
 				<p>This rule is not required for conformance to WCAG at any level.</p>
 			</div>
 		)
 	}
 
-	const conformanceRequirements = Object.keys(accessibility_requirements)
-		.filter(key => {
-			const value = accessibility_requirements[key]
+	const conformanceRequirements = Object.entries(accessibility_requirements)
+		.filter(([_, value]) => {
 			if (!value) {
 				return false
 			}
@@ -271,21 +271,23 @@ export function getAccessibilityRequirements(
 			return !!forConformance
 		})
 
-	const getOutcomeMapping = () => {
+	const getOutcomeMapping = ({
+		failed = 'not satisfied',
+		passed = 'further testing is needed',
+		inapplicable = 'further testing is needed'
+	} = {}) => {
 		return (
 			<li>
 				Outcome mapping:
 				<ul>
 					<li>
-						Any <code>failed</code> outcomes: not satisfied
+						Any <code>failed</code> outcomes: { failed }
 					</li>
 					<li>
-						All <code>passed</code> outcomes: further testing is
-						needed
+						All <code>passed</code> outcomes: { passed }
 					</li>
 					<li>
-						An <code>inapplicable</code> outcome: further testing is
-						needed
+						An <code>inapplicable</code> outcome: { inapplicable }
 					</li>
 				</ul>
 			</li>
@@ -330,12 +332,12 @@ export function getAccessibilityRequirements(
 		)
 	}
 
-	const ariaListing = (key, req, listType) => {
+	const ariaListing = (key, mapping, listType) => {
 		const ref = key.split(':').slice(-1).pop();
 		
 		if (listType === 'text') {
 			return (
-				<li key={ref}>{req.title}</li>
+				<li key={ref}>{mapping.title}</li>
 			)
 		}
 
@@ -344,7 +346,7 @@ export function getAccessibilityRequirements(
 			<li key={ref}>
 				<details>
 					<summary>
-						{req.title}
+						{mapping.title}
 					</summary>
 					<ul>
 						<li>
@@ -353,13 +355,13 @@ export function getAccessibilityRequirements(
 								href={href}
 								target="_blank"
 								rel="noopener noreferrer">
-								Learn More about {req.title}
+								Learn More about {mapping.title}
 							</a>
 						</li>
 						<li>
 							<strong>Required for conformance</strong>
 						</li>
-						{getOutcomeMapping()}
+						{getOutcomeMapping(mapping)}
 					</ul>
 				</details>
 			</li>
@@ -368,11 +370,11 @@ export function getAccessibilityRequirements(
 
 	return (
 		<div className="meta">
-			<span className="heading">Accessibility Requirements</span>
+			<span className="heading">Accessibility Requirements Mapping</span>
 			<ul>
-				{conformanceRequirements.map(req => {
+				{conformanceRequirements.map(([req, mapping]) => {
 					if(req.toLowerCase().includes('aria11')) {
-						return ariaListing(req, accessibility_requirements[req], type)
+						return ariaListing(req, mapping, type)
 					}
 
 					if(req.toLowerCase().includes('wcag')) {
@@ -525,7 +527,7 @@ export function getGlossaryUsageInRules(usages) {
  * Get formatted date from unix timestamp
  * @param {String} unixtimestamp UNIX timestamp
  */
-function getDateTimeFromUnixTimestamp(unixtimestamp) {
+export function getDateTimeFromUnixTimestamp(unixtimestamp) {
 	const months_arr = [
 		'Jan',
 		'Feb',


### PR DESCRIPTION
This PR fixes a couple of things:

1. Always include the "outcome" definition
2. Display the rule ID
3. Display the last modified date
4. Make sure the "useful links" section isn't hidden when the ToC doesn't fit the screen
5. Ensure "satisfied" tests can be displayed correctly.
6. Rename "Accessibility requirements" to "Accessibility requirements mapping", as it is in the spec.