### PR TITLE
[RFC] Examples in glossary

### DIFF
--- a/_rules/button-has-name-97a4e1.md
+++ b/_rules/button-has-name-97a4e1.md
@@ -55,22 +55,6 @@ Regular button.
 <button>My button</button>
 ```
 
-#### Passed Example 2
-
-Value attribute as the accessible name.
-
-```html
-<input type="submit" value="Submit" />
-```
-
-#### Passed Example 3
-
-`aria-label` for the accessible name.
-
-```html
-<button aria-label="My button"></button>
-```
-
 #### Passed Example 4
 
 Span tag with role button and has name defined by aria-label.
@@ -131,14 +115,6 @@ Input button has an accessible name that comes from the default "reset" text.
 ```
 
 ### Failed
-
-#### Failed Example 1
-
-Value attribute does NOT give an accessible name, only for input elements.
-
-```html
-<button type="button" value="read more"></button>
-```
 
 #### Failed Example 2
 

--- a/_rules/image-has-name-23a2a8.md
+++ b/_rules/image-has-name-23a2a8.md
@@ -59,22 +59,6 @@ The HTML `img` element has an accessible name
 <img alt="W3C logo" />
 ```
 
-#### Passed Example 2
-
-The element with role of `img` has an accessible name
-
-```html
-<div role="img" aria-label="W3C logo"></div>
-```
-
-#### Passed Example 3
-
-The element has an accessible name, though the name is not always accessibility supported
-
-```html
-<img title="W3C logo" />
-```
-
 #### Passed Example 4
 
 The HTML `img` element is marked as [decorative](#decorative) through an empty `alt` attribute

--- a/pages/glossary/accessible-name.md
+++ b/pages/glossary/accessible-name.md
@@ -8,3 +8,63 @@ The programmatically determined name of a user interface element that is include
 The accessible name is calculated using the [accessible name and description computation](https://www.w3.org/TR/accname).
 
 For native markup languages, such as HTML and SVG, additional information on how to calculate the accessible name can be found in [HTML Accessibility API Mappings 1.0, Accessible Name and Description Computation](https://www.w3.org/TR/html-aam/#accessible-name-and-description-computation) and [SVG Accessibility API Mappings, Name and Description](https://www.w3.org/TR/svg-aam/#mapping_additional).
+
+
+#### Examples
+
+##### Example 1
+
+This `button` has an accessible name given by its text content.
+
+```html
+<button>My button</button>
+```
+
+##### Example 2
+
+This link has an accessible name given by its `title` attribute.
+
+```html
+<a href="http://www.w3.org/WAI" title="This is a link"><img src="#"/></a>
+```
+
+##### Example 3
+
+This `div` has an accessible name given by its `aria-label` attribute.
+
+```html
+<div aria-label="Empty element"></div>
+```
+
+##### Example 4
+
+This `img` has an accessible name given by `aria-labelledby`.
+
+```html
+<div id="label-cat-cucumber">A cat being afraid of a cucumber</div>
+<img aria-labelledby="label-cat-cucumber" src="cat-cucumber.jpg">
+```
+
+##### Example 5
+
+This `input` as an accessible name given by its `value` attribute.
+
+```html
+<input type="submit" value="Submit" />
+```
+
+##### Example 6
+
+This `img` has an accessible name given by its `alt` attribute.
+
+```html
+<img alt="A cat being afraid of a cucumber" src="cat-cucumber.jpg">
+```
+
+##### Example 7
+
+This `button` does not have an accessible name, since `value` attribute is only for `input`
+
+```html
+<button type="button" value="read more"></button>
+```


### PR DESCRIPTION
Follow-up to #182.

# Why?
Many examples in the rules are actually variations on some glossary definition rather than illustrating the rule. For example, in [Links have an accessible name](https://act-rules.github.io/rules/c487ae), Passed Example 4, 5, 6, 7, and 8 are just variations on how to give an accessible name to a link, *i.e.* they are illustrations of the definition of accessible name, not illustration of the rule.

This is bad from a rule-writing point-of-view since we have to remember to create examples of every single variation of every glossary item used which creates a pointless overhead. (and, by the way, many rules are missing accessible names given by `aria-labelledby`)

This is bad from a pedagogical point of view since it adds tons of examples who are illustrating something else than the current topic (*i.e.* the glossary item rather than the rule), creating a cognitive overhead of "oh, yeah, this is just another way to give accessible name"

# What?
I've tried to put some examples in one of the glossary item and remove redundant examples from some of the corresponding rule to give an idea of what it could look like. This obviously would require more work, and more polished work…

# Pros
Rules become easier to write and more to the point, hence easier to read.

Glossary becomes easier to understand with examples illustrating the definition.

# Cons
Glossary becomes harder to write but this should be balanced by the ease of writing rule.
In some case, it might however, become a real mess, typically with `value` giving an accessible name to `input` but not to `button`… 

Rules would still need a bit of variation in the examples. If all rules always only use `aria-label` to give an accessible name, this is not very good. We need one rule to use one way, and another one to use another way (or variation between examples), which can be harder to maintain in a reasonably good balance between the possibilities.

Glossary will need to be tested by checker engines. Currently, we do not test that all checker engines compute the accessible name in the same way, but the many examples all over the place act as such a test: if an engine forgets about `aria-label`, it will fail on many passed examples and we will detect that. If these variations are mostly written in the glossary, we need to run tests on these. It is less clear what the outcome of these tests are (what does "passed" mean?, not much… the outcome of accessible name should be the computed accessible name, but then how to store that within the test case?)