### PR TITLE
chore: test if composite rules only refer to atomic rules as `input_rules`

### DIFF
--- a/_rules/__tests__/frontmatter.js
+++ b/_rules/__tests__/frontmatter.js
@@ -2,7 +2,7 @@ const describeRule = require('../../test-utils/describe-rule')
 const { contributors } = require('./../../package.json')
 const contributorsNames = contributors.map(contributor => contributor.name.toLowerCase())
 
-describeRule('frontmatter', ruleData => {
+describeRule('frontmatter', (ruleData, metaData) => {
 	const { frontmatter } = ruleData
 	const { rule_type, authors, accessibility_requirements } = frontmatter
 
@@ -22,7 +22,14 @@ describeRule('frontmatter', ruleData => {
 			expect(frontmatter).toHaveProperty('input_rules')
 			expect(frontmatter).not.toHaveProperty('input_aspects')
 		})
+
+		const { atomicRuleIds } = metaData
+		const { input_rules } = frontmatter
+		test('if `composite` rule only refers to `atomic` rules in `input_rules`', () => {
+			expect(atomicRuleIds).toIncludeAllMembers(input_rules);
+		})
 	}
+
 	if (rule_type.toLowerCase() === `atomic`) {
 		test('has optional property `input_aspects` when `rule_type = atomic`', () => {
 			expect(frontmatter).toHaveProperty('input_aspects')

--- a/test-utils/describe-rule.js
+++ b/test-utils/describe-rule.js
@@ -1,19 +1,42 @@
 const getRulesMarkdownData = require('../utils/get-rules-markdown-data')
 
 /**
+ * Get ids of rules that are of given type
+ * @param {Array<Object>} rules list of rules
+ * @param {String} ruleType type of rule
+ */
+const getRuleIdsOfRuleType = (rules, ruleType) => {
+  return rules.reduce((out, ruleData) => {
+    const { frontmatter } = ruleData
+    const { rule_type, id } = frontmatter
+    if (rule_type === ruleType) {
+      out.push(id)
+    }
+    return out
+  }, [])
+}
+
+/**
  * describe rule helper
  * @param {String} groupName name of the `describe` block
  * @param {Function} runTests function callback of `describe` block, which executes per rule
  */
 const describeRule = (groupName, runTests) => {
-
   const rules = getRulesMarkdownData()
+
+  /**
+   * Create arbitrary meta data that can be used in various tests
+   */
+  const atomicRuleIds = getRuleIdsOfRuleType(rules, 'atomic')
+  const metaData = {
+    atomicRuleIds,
+  }
 
   rules.forEach(ruleData => {
     const { filename } = ruleData
     describe(filename, () => {
       describe(groupName, () => {
-        runTests(ruleData)
+        runTests(ruleData, metaData)
       })
     })
   })


### PR DESCRIPTION
- added test to verify if `composite` rule type only refers to `atomic` rules as `input_rules`.
- the actual fix for changing the rule id is here - https://github.com/act-rules/act-rules.github.io/pull/721

Closes issue(s): 
- https://github.com/act-rules/act-rules.github.io/issues/625

----

## Pull Request Etiquette

### **When creating PR:**
- Make sure you requesting to **pull a branch** (right side) to the `develop` branch (left side).

### **After creating PR:**
- Add yourself (and co-authors) as "Assignees" for PR.
- Add label to indicate if it's a `Rule`, `Definition` or `Chore`.
- Close the issue that the PR resolves (and make sure the issue is referenced in the top of this comment)
- Optionally request feedback from anyone in particular by assigning them as "Reviewers".

## How to Review And Approve
- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines. 
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.