### PR TITLE
fix(test): glossary test should look for key over filename

### DIFF
--- a/pages/glossary/__tests__/glossary-exists.js
+++ b/pages/glossary/__tests__/glossary-exists.js
@@ -1,12 +1,20 @@
 const globby = require('globby')
+const getMarkdownData = require('../../../utils/get-markdown-data')
 const glossaryUsages = require('../../../_data/glossary-usages.json')
-const glossaryFiles = globby.sync([`./pages/glossary/*.md`]).map(path => path.replace('./pages/glossary/', ''))
+
+const glossaryKeys = globby
+	.sync([`./pages/glossary/*.md`])
+	.map(path => getMarkdownData(path))
+	.map(data => {
+		const {
+			frontmatter: { key },
+		} = data
+		return `#${key}`
+	})
 
 describe('all referenced glossary terms exist', () => {
 	test.each(Object.keys(glossaryUsages))('has glossary file `%s`', glossaryKey => {
-		const filename = `${glossaryKey.replace('#', '')}.md`
-		const fileExists = glossaryFiles.includes(filename)
-
+		const fileExists = glossaryKeys.includes(glossaryKey)
 		if (!fileExists) {
 			console.log(`glossary missing for ${glossaryKey}, usages below:`)
 			console.table(glossaryUsages[glossaryKey])


### PR DESCRIPTION
Update test for glossary term existence to check against the `key` attribute used in the `frontmatter`, over comparing existence of file. This allows for naming glossary term files differently than the actual key (Example: https://github.com/act-rules/act-rules.github.io/pull/255/files#diff-e8efc5e044aa522fbb04b4f072890fa3)

Closes issue(s): 
- NA

----

## Pull Request Etiquette

### **When creating PR:**
- Make sure you requesting to **pull a branch** (right side) to the `develop` branch (left side).

### **After creating PR:**
- Add yourself (and co-authors) as "Assignees" for PR.
- Add label to indicate if it's a `Rule`, `Definition` or `Chore`.
- Close the issue that the PR resolves (and make sure the issue is referenced in the top of this comment)
- Optionally request feedback from anyone in particular by assigning them as "Reviewers".

## How to Review And Approve
- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines. 
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.