### PR TITLE
chore: bust cache of HTML pages served by GitHub Pages.

### DIFF
--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -25,6 +25,20 @@ function SEO({ description, lang, meta, keywords, title }) {
 		`
 	)
 
+	const metaKeywords = keywords.length > 0
+		? {
+			name: `keywords`,
+			content: keywords.join(`, `),
+		}
+		: []
+
+	const metaTags = [
+		{ name: `description`, content: metaDescription, },
+		{ property: `og:title`, content: title, },
+		{ property: `og:description`, content: metaDescription, },
+		{ property: `og:type`, content: `website`, },
+	].concat(metaKeywords).concat(meta)
+
 	const metaDescription = description || site.siteMetadata.description
 	return (
 		<Helmet
@@ -33,34 +47,14 @@ function SEO({ description, lang, meta, keywords, title }) {
 			}}
 			title={title}
 			titleTemplate={`%s | ${site.siteMetadata.title}`}
-			meta={[
-				{
-					name: `description`,
-					content: metaDescription,
-				},
-				{
-					property: `og:title`,
-					content: title,
-				},
-				{
-					property: `og:description`,
-					content: metaDescription,
-				},
-				{
-					property: `og:type`,
-					content: `website`,
-				},
-			]
-				.concat(
-					keywords.length > 0
-						? {
-								name: `keywords`,
-								content: keywords.join(`, `),
-						  }
-						: []
-				)
-				.concat(meta)}
-		/>
+			meta={metaTags}
+		>
+			{/* Busting cache as advised by Gatsby  */}
+			{/* See - https://github.com/gatsbyjs/gatsby/blob/master/docs/docs/caching.md */}
+			<meta http-equiv="Cache-Control" content="public, max-age=0, must-revalidate" />
+			<meta http-equiv="Pragma" content="no-cache" />
+			<meta http-equiv="Expires" content="0" />
+		</Helmet>
 	)
 }
 


### PR DESCRIPTION
Noticed some aggressive caching of pages served by `gh-pages`, adding on top of all the caching offered by Gatsby, it was best to set the right headers as advised here - https://github.com/gatsbyjs/gatsby/blob/master/docs/docs/caching.md

There was no easy way to change the headers of Github Pages, and hence resorting to set these via the meta tag.

Closes issue(s): 
- NA

----

## Pull Request Etiquette

### **When creating PR:**
- Make sure you requesting to **pull a branch** (right side) to the `develop` branch (left side).

### **After creating PR:**
- Add yourself (and co-authors) as "Assignees" for PR.
- Add label to indicate if it's a `Rule`, `Definition` or `Chore`.
- Close the issue that the PR resolves (and make sure the issue is referenced in the top of this comment)
- Optionally request feedback from anyone in particular by assigning them as "Reviewers".

## How to Review And Approve
- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines. 
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.