### PR TITLE
fix: rule 80af7b - failing tests for rule - No keyboard trap standard navigation

### DIFF
--- a/_rules/no-keyboard-trap-80af7b.md
+++ b/_rules/no-keyboard-trap-80af7b.md
@@ -169,14 +169,16 @@ Keyboard trap one element.
 Keyboard trap group.
 
 ```html
-<button class="target" onblur="setTimeout(() => this.nextSibling.focus(), 10)">
+<button class="target" onblur="setTimeout(() => this.nextElementSibling.focus(), 10)">
 	Button1
 </button>
-<button class="target" onblur="setTimeout(() => this.previousSibling.focus(), 10)">
+<button class="target" onblur="setTimeout(() => this.previousElementSibling.focus(), 10)">
 	Button2
 </button>
+<button>
+	Button3
+</button>
 ```
-
 #### Failed Example 3
 
 A focusable element inbetween to keyboard traps.


### PR DESCRIPTION
Change the failed test case 2. This test case is the same as in the atomic rule  "No keyboard trap standard navigation" where it was fixed.

See the related commit : https://github.com/act-rules/act-rules.github.io/commit/af55b85eda8a8aa26a7965aaed5f23e6a267d43a#diff-ebbcb950ef3b644c6747d9b3c601e329

This PR is just applying the same correction on the composite rule.

