### PR TITLE
Improve note on excluding option

### DIFF
--- a/_rules/form-field-has-name-e086e5.md
+++ b/_rules/form-field-has-name-e086e5.md
@@ -25,7 +25,8 @@ This rule applies to any element that is [included in the accessibility tree](#i
 
 - have a [semantic roles](#semantic-role) that inherits from the [abstract](https://www.w3.org/TR/wai-aria/#abstract_roles) `input` or `select` role, and
 - does not have a [required context](https://www.w3.org/TR/wai-aria/#scope) role that itself inherits from one of those roles.
-- The `option` role is not part of the list of applicable roles, because it does not meet the definition of a [User interface component](https://www.w3.org/TR/WCAG21/#dfn-user-interface-components). This means [WCAG 2.1](https://www.w3.org/TR/WCAG21/) does not require it to have an accessible name.
+
+**Note:** The `option` role is not part of the list of applicable roles, because it has a required context role that inherits from the `select` role. Furthermore, `option` does not meet the definition of a [User interface component](https://www.w3.org/TR/WCAG21/#dfn-user-interface-components). This means [WCAG 2.1](https://www.w3.org/TR/WCAG21/) does not require it to have an accessible name.
 
 ## Expectation
 


### PR DESCRIPTION
Updating the note on applicability about why `option` is excluded.
(does not require Final Call)

Closes issue(s): 
- follow the remark in https://github.com/act-rules/act-rules.github.io/pull/447#discussion_r269100490

----

## Pull Request Etiquette

### **When creating PR:**
- Make sure you requesting to **pull a branch** (right side) to the `develop` branch (left side).

### **After creating PR:**
- Add yourself (and co-authors) as "Assignees" for PR.
- Add label to indicate if it's a `Rule`, `Definition` or `Chore`.
- Close the issue that the PR resolves (and make sure the issue is referenced in the top of this comment)
- Optionally request feedback from anyone in particular by assigning them as "Reviewers".

## How to Review And Approve
- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines. 
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.