### PR TITLE
chore: Improve glossary detection regexps

### DIFF
--- a/utils/reg-exps.js
+++ b/utils/reg-exps.js
@@ -16,10 +16,10 @@ const regexps = {
 		1. Classical usage => 'this is a link [link](key)'
 		\(([^)]+)\) => one or more non-'(' within parenthesis and remember the content of the parenthesis as first group.
 		2. Internal reference => '[refname]: key "title"'
-		/.*:\s+(.*)\s+/ => drop everything before the ':', remember the space separated first word after it.
+		/.*:\s+(#.*)\s+/ => drop everything before the ':', remember the space separated first word after it if it starts with # (otherwise, it's a link to an external page).
 	*/
 	glossaryKey: /\(([^)]+)\)/,
-	glossaryKeyInDefinition: /.*:\s+(.*)\s+/,
+	glossaryKeyInDefinition: /.*:\s+(#.*)\s+/,
 }
 
 module.exports = regexps


### PR DESCRIPTION
Regexp for short refs style was catching external refs (`https://…`) and considering them as (missing) glossary items.