### PR TITLE
Make all test asset paths root relative

### DIFF
--- a/_rules/audio-as-media-alternative-afb423.md
+++ b/_rules/audio-as-media-alternative-afb423.md
@@ -67,7 +67,7 @@ An audio element that describes some of the text on the same page. The text on t
 <p>
 	You can also listen to the audio file below to hear the above part of the speech.
 </p>
-<audio src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
+<audio src="/test-assets/moon-audio/moon-speech.mp3" controls></audio>
 ```
 
 ### Failed
@@ -84,7 +84,7 @@ An audio element that describes some of the text on the same page. The audio con
 <p>
 	You can also listen to the audio file below to hear the above part of the speech.
 </p>
-<audio src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
+<audio src="/test-assets/moon-audio/moon-speech.mp3" controls></audio>
 ```
 
 #### Failed Example 2
@@ -101,7 +101,7 @@ An audio element that describes some of the text on the same page. The text is n
 <p>
 	You can also listen to the audio file below to hear the above part of the speech.
 </p>
-<audio src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
+<audio src="/test-assets/moon-audio/moon-speech.mp3" controls></audio>
 ```
 
 #### Failed Example 3
@@ -115,7 +115,7 @@ An audio element that describes some of the text on the same page. The text on t
 	energies and skills, because that challenge is one that we are willing to accept, one we are unwilling to postpone,
 	and one which we intend to win, and the others, too.
 </p>
-<audio src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
+<audio src="/test-assets/moon-audio/moon-speech.mp3" controls></audio>
 ```
 
 #### Failed Example 4
@@ -132,7 +132,7 @@ An audio element that describes some of the text on the same page. The text on t
 <p style="display: none;">
 	You can also listen to the audio file below to hear the above part of the speech.
 </p>
-<audio src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
+<audio src="/test-assets/moon-audio/moon-speech.mp3" controls></audio>
 ```
 
 ### Inapplicable
@@ -151,7 +151,7 @@ An audio element that describes some of the text on the same page. The text on t
 <p>
 	You can also listen to the audio file below to hear the above part of the speech.
 </p>
-<audio src="../test-assets/moon-audio/moon-speech.mp3" controls style="display: none;"></audio>
+<audio src="/test-assets/moon-audio/moon-speech.mp3" controls style="display: none;"></audio>
 ```
 
 #### Inapplicable Example 2
@@ -169,7 +169,7 @@ An audio element that describes some of the text on the same page. The text on t
 	You can also listen to the audio file below to hear the above part of the speech.
 </p>
 
-<audio src="../test-assets/moon-audio/moon-speech.mp3"></audio>
+<audio src="/test-assets/moon-audio/moon-speech.mp3"></audio>
 ```
 
 [included in the accessibility tree]: #included-in-the-accessibility-tree 'Definition of included in the accessibility tree'

--- a/_rules/audio-have-transcript-2eb176.md
+++ b/_rules/audio-have-transcript-2eb176.md
@@ -52,7 +52,7 @@ There are no major accessibility support issues known for this rule.
 Audio with controls and internal transcript
 
 ```html
-<audio src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
+<audio src="/test-assets/moon-audio/moon-speech.mp3" controls></audio>
 <p>
 	The above audio contains the following speech: We choose to go to the moon in this decade and do the other things, not
 	because they are easy, but because they are hard, because that goal will serve to organize and measure the best of our
@@ -66,7 +66,7 @@ Audio with controls and internal transcript
 Audio with controls and external transcript
 
 ```html
-<audio src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
+<audio src="/test-assets/moon-audio/moon-speech.mp3" controls></audio>
 <a href="/test-assets/moon-audio/moon-speech-transcript.html">Transcript</a>
 ```
 
@@ -75,7 +75,7 @@ Audio with controls and external transcript
 Audio with autoplay and external transcript
 
 ```html (no-iframe)
-<audio src="../test-assets/moon-audio/moon-speech.mp3" autoplay></audio>
+<audio src="/test-assets/moon-audio/moon-speech.mp3" autoplay></audio>
 <a href="/test-assets/moon-audio/moon-speech-transcript.html">Transcript</a>
 ```
 
@@ -86,7 +86,7 @@ Audio with autoplay and external transcript
 Audio with controls and no transcript
 
 ```html
-<audio src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
+<audio src="/test-assets/moon-audio/moon-speech.mp3" controls></audio>
 ```
 
 #### Failed Example 2
@@ -94,7 +94,7 @@ Audio with controls and no transcript
 Audio with controls and incorrect internal transcript
 
 ```html
-<audio src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
+<audio src="/test-assets/moon-audio/moon-speech.mp3" controls></audio>
 <p>
 	The above audio contains the following speech: We choose to go to the cheese in this decade and do the other things,
 	not because they are easy, but because they are hard, because that goal will serve to organize and measure the best of
@@ -108,7 +108,7 @@ Audio with controls and incorrect internal transcript
 Audio with controls and incorrect external transcript
 
 ```html
-<audio src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
+<audio src="/test-assets/moon-audio/moon-speech.mp3" controls></audio>
 <a href="/test-assets/moon-audio/moon-speech-incorrect-transcript.html">Transcript</a>
 ```
 
@@ -117,7 +117,7 @@ Audio with controls and incorrect external transcript
 Audio with autoplay and incorrect external transcript
 
 ```html (no-iframe)
-<audio src="../test-assets/moon-audio/moon-speech.mp3" autoplay></audio>
+<audio src="/test-assets/moon-audio/moon-speech.mp3" autoplay></audio>
 <a href="/test-assets/moon-audio/moon-speech-incorrect-transcript.html">Transcript</a>
 ```
 
@@ -126,7 +126,7 @@ Audio with autoplay and incorrect external transcript
 Audio with controls and [non-visible][visible] internal transcript
 
 ```html
-<audio src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
+<audio src="/test-assets/moon-audio/moon-speech.mp3" controls></audio>
 <p style="text-indent: -9999px;">
 	The above audio contains the following speech: We choose to go to the moon in this decade and do the other things, not
 	because they are easy, but because they are hard, because that goal will serve to organize and measure the best of our
@@ -140,7 +140,7 @@ Audio with controls and [non-visible][visible] internal transcript
 Audio with controls and internal transcript that is not exposed to the accessibility tree
 
 ```html
-<audio src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
+<audio src="/test-assets/moon-audio/moon-speech.mp3" controls></audio>
 <p aria-hidden="true">
 	The above audio contains the following speech: We choose to go to the moon in this decade and do the other things, not
 	because they are easy, but because they are hard, because that goal will serve to organize and measure the best of our
@@ -156,7 +156,7 @@ Audio with controls and internal transcript that is not exposed to the accessibi
 Audio without controls.
 
 ```html
-<audio src="../test-assets/moon-audio/moon-speech.mp3"></audio>
+<audio src="/test-assets/moon-audio/moon-speech.mp3"></audio>
 ```
 
 #### Inapplicable Example 2
@@ -164,7 +164,7 @@ Audio without controls.
 Audio with hidden controls.
 
 ```html
-<audio src="../test-assets/moon-audio/moon-speech.mp3" controls style="display: none;"></audio>
+<audio src="/test-assets/moon-audio/moon-speech.mp3" controls style="display: none;"></audio>
 ```
 
 [included in the accessibility tree]: #included-in-the-accessibility-tree 'Definition of included in the accessibility tree'

--- a/_rules/audio-only-text-alternative-e7aa44.md
+++ b/_rules/audio-only-text-alternative-e7aa44.md
@@ -58,7 +58,7 @@ There are no major accessibility support issues known for this rule.
 Audio with controls and internal transcript
 
 ```html
-<audio data-rule-target src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
+<audio data-rule-target src="/test-assets/moon-audio/moon-speech.mp3" controls></audio>
 <p>
 	The above audio contains the following speech: We choose to go to the moon in this decade and do the other things, not
 	because they are easy, but because they are hard, because that goal will serve to organize and measure the best of our
@@ -81,7 +81,7 @@ An audio element that describes some of the text on the same page. The text on t
 <p>
 	You can also listen to the audio file below to hear the above part of the speech.
 </p>
-<audio data-rule-target src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
+<audio data-rule-target src="/test-assets/moon-audio/moon-speech.mp3" controls></audio>
 ```
 
 ### Failed
@@ -91,7 +91,7 @@ An audio element that describes some of the text on the same page. The text on t
 Audio with controls and incorrect internal transcript
 
 ```html
-<audio data-rule-target src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
+<audio data-rule-target src="/test-assets/moon-audio/moon-speech.mp3" controls></audio>
 <p>
 	The above audio contains the following speech: We choose to go to the cheese in this decade and do the other things,
 	not because they are easy, but because they are hard, because that goal will serve to organize and measure the best of
@@ -114,7 +114,7 @@ An audio element that describes some of the text on the same page. The text is n
 <p>
 	You can also listen to the audio file below to hear the above part of the speech.
 </p>
-<audio data-rule-target src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
+<audio data-rule-target src="/test-assets/moon-audio/moon-speech.mp3" controls></audio>
 ```
 
 ### Inapplicable
@@ -124,7 +124,7 @@ An audio element that describes some of the text on the same page. The text is n
 Audio without controls.
 
 ```html
-<audio src="../test-assets/moon-audio/moon-speech.mp3"></audio>
+<audio src="/test-assets/moon-audio/moon-speech.mp3"></audio>
 ```
 
 #### Inapplicable Example 2
@@ -141,7 +141,7 @@ An audio element that describes some of the text on the same page. The text on t
 <p>
 	You can also listen to the audio file below to hear the above part of the speech.
 </p>
-<audio data-rule-target src="../test-assets/moon-audio/moon-speech.mp3" controls style="display: none;"></audio>
+<audio data-rule-target src="/test-assets/moon-audio/moon-speech.mp3" controls style="display: none;"></audio>
 ```
 
 [visible]: #visible 'Definition of visible'

--- a/_rules/descriptive-heading-b49b2e.md
+++ b/_rules/descriptive-heading-b49b2e.md
@@ -84,7 +84,7 @@ Heading marked up with `h1` element with an image that describes the topic or pu
 
 ```html
 <h1 class="target">
-	<img scr="../test-assets/descriptive-heading-b49b2e/opening_hours_icon.png" alt="Opening hours" />
+	<img scr="/test-assets/descriptive-heading-b49b2e/opening_hours_icon.png" alt="Opening hours" />
 </h1>
 <p>We are open Monday through Friday from 10 to 16</p>
 ```

--- a/_rules/html-has-title-2779a5.md
+++ b/_rules/html-has-title-2779a5.md
@@ -77,7 +77,7 @@ This page gives a `title` to an iframe.
 ```html
 <html>
 	<title>This page gives a title to an iframe</title>
-	<iframe src="../test-assets/sc2-4-2-title-page-without-title.html"></iframe>
+	<iframe src="/test-assets/sc2-4-2-title-page-without-title.html"></iframe>
 </html>
 ```
 
@@ -161,7 +161,7 @@ The page has no `title`.
 
 ```html
 <html>
-	<iframe src="../test-assets/sc2-4-2-title-page-with-title.html"></iframe>
+	<iframe src="/test-assets/sc2-4-2-title-page-with-title.html"></iframe>
 </html>
 ```
 

--- a/_rules/iframe-has-name-cae760.md
+++ b/_rules/iframe-has-name-cae760.md
@@ -51,7 +51,7 @@ _There are no major accessibility support issues known for this rule._
 Usage of `title` attribute to describe the `iframe` content.
 
 ```html
-<iframe title="List of Contributors" src="../test-assets/SC4-1-2-frame-doc.html"> </iframe>
+<iframe title="List of Contributors" src="/test-assets/SC4-1-2-frame-doc.html"> </iframe>
 ```
 
 #### Passed Example 2
@@ -59,7 +59,7 @@ Usage of `title` attribute to describe the `iframe` content.
 Usage of `aria-label` attribute to describe the `iframe` content.
 
 ```html
-<iframe aria-label="Advertisement of tours to Great Wall of China" src="../test-assets/SC4-1-2-frame-doc.html">
+<iframe aria-label="Advertisement of tours to Great Wall of China" src="/test-assets/SC4-1-2-frame-doc.html">
 </iframe>
 ```
 
@@ -69,7 +69,7 @@ Usage of `aria-labelledby` attribute to describe the `iframe` content.
 
 ```html
 <div id="frame-title-helper">Watch highlights of the Worldcup</div>
-<iframe aria-labelledby="frame-title-helper" src="../test-assets/SC4-1-2-frame-doc.html"> </iframe>
+<iframe aria-labelledby="frame-title-helper" src="/test-assets/SC4-1-2-frame-doc.html"> </iframe>
 ```
 
 #### Passed Example 4
@@ -77,7 +77,7 @@ Usage of `aria-labelledby` attribute to describe the `iframe` content.
 [Accessible name][] is not only [whitespace][].
 
 ```html
-<iframe title=":-)" src="../test-assets/SC4-1-2-frame-doc.html"> </iframe>
+<iframe title=":-)" src="/test-assets/SC4-1-2-frame-doc.html"> </iframe>
 ```
 
 ### Failed
@@ -87,7 +87,7 @@ Usage of `aria-labelledby` attribute to describe the `iframe` content.
 Usage of `name` attribute to describe the `iframe` content is not valid.
 
 ```html
-<iframe name="List of Contributors" src="../test-assets/SC4-1-2-frame-doc.html"> </iframe>
+<iframe name="List of Contributors" src="/test-assets/SC4-1-2-frame-doc.html"> </iframe>
 ```
 
 #### Failed Example 2
@@ -95,7 +95,7 @@ Usage of `name` attribute to describe the `iframe` content is not valid.
 `iframe` with no `title`, `aria-label` or `aria-labelledby` attribute to describe content is not valid.
 
 ```html
-<iframe src="../test-assets/SC4-1-2-frame-doc.html"> </iframe>
+<iframe src="/test-assets/SC4-1-2-frame-doc.html"> </iframe>
 ```
 
 #### Failed Example 3
@@ -103,7 +103,7 @@ Usage of `name` attribute to describe the `iframe` content is not valid.
 Empty `title` attribute is not valid.
 
 ```html
-<iframe title="" src="../test-assets/SC4-1-2-frame-doc.html"> </iframe>
+<iframe title="" src="/test-assets/SC4-1-2-frame-doc.html"> </iframe>
 ```
 
 #### Failed Example 4
@@ -111,7 +111,7 @@ Empty `title` attribute is not valid.
 Empty `aria-label` attribute to describe the `frame` content is not valid.
 
 ```html
-<iframe aria-label="" src="../test-assets/SC4-1-2-frame-doc.html"> </iframe>
+<iframe aria-label="" src="/test-assets/SC4-1-2-frame-doc.html"> </iframe>
 ```
 
 #### Failed Example 5
@@ -119,7 +119,7 @@ Empty `aria-label` attribute to describe the `frame` content is not valid.
 Usage of non existing `aria-labelledby` reference element to describe the `iframe` content is not valid.
 
 ```html
-<iframe aria-labelledby="does-not-exist" src="../test-assets/SC4-1-2-frame-doc.html"> </iframe>
+<iframe aria-labelledby="does-not-exist" src="/test-assets/SC4-1-2-frame-doc.html"> </iframe>
 ```
 
 #### Failed Example 6
@@ -127,7 +127,7 @@ Usage of non existing `aria-labelledby` reference element to describe the `ifram
 Usage of `alt` attribute to describe content is not valid.
 
 ```html
-<iframe alt="List of Contributors" src="../test-assets/SC4-1-2-frame-doc.html"> </iframe>
+<iframe alt="List of Contributors" src="/test-assets/SC4-1-2-frame-doc.html"> </iframe>
 ```
 
 #### Failed Example 7
@@ -135,7 +135,7 @@ Usage of `alt` attribute to describe content is not valid.
 [Accessible name][] is only [whitespace][].
 
 ```html
-<iframe title=" " src="../test-assets/SC4-1-2-frame-doc.html"> </iframe>
+<iframe title=" " src="/test-assets/SC4-1-2-frame-doc.html"> </iframe>
 ```
 
 ### Inapplicable
@@ -153,7 +153,7 @@ Does not apply to non `iframe` element.
 `iframe` is not [included in the accessibility tree][].
 
 ```html
-<iframe style="display:none;" src="../test-assets/SC4-1-2-frame-doc.html"> </iframe>
+<iframe style="display:none;" src="/test-assets/SC4-1-2-frame-doc.html"> </iframe>
 ```
 
 [accessible name]: #accessible-name 'Definition of accessible name'

--- a/_rules/iframe-unique-name-4b1c6c.md
+++ b/_rules/iframe-unique-name-4b1c6c.md
@@ -52,9 +52,9 @@ _There are no major accessibility support issues known for this rule._
 Multiple `iframe` within document tree have the same [accessible name][] (given by `title`) and embed the same resource.
 
 ```html
-<iframe title="List of Contributors" src="../test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
+<iframe title="List of Contributors" src="/test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
 
-<iframe title="List of Contributors" src="../test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
+<iframe title="List of Contributors" src="/test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
 ```
 
 #### Passed Example 2
@@ -62,9 +62,9 @@ Multiple `iframe` within document tree have the same [accessible name][] (given 
 Multiple `iframe` within document tree have the same [accessible name][] (given by `title` and `aria-label`) and embed the same resource.
 
 ```html
-<iframe title="List of Contributors" src="../test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
+<iframe title="List of Contributors" src="/test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
 
-<iframe aria-label="List of Contributors" src="../test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
+<iframe aria-label="List of Contributors" src="/test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
 ```
 
 #### Passed Example 3
@@ -73,10 +73,10 @@ Multiple `iframe` within document tree have the same [accessible name][] (given 
 
 ```html
 <div id="desc-for-title">List of Contributors</div>
-<iframe aria-labelledby="desc-for-title" src="../test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
+<iframe aria-labelledby="desc-for-title" src="/test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
 
 <div id="desc-for-title1">List of Contributors</div>
-<iframe aria-labelledby="desc-for-title1" src="../test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
+<iframe aria-labelledby="desc-for-title1" src="/test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
 ```
 
 #### Passed Example 4
@@ -84,9 +84,9 @@ Multiple `iframe` within document tree have the same [accessible name][] (given 
 Multiple `iframe` within document tree have the same [accessible name][] (given by `title`) and embed equivalent resources. Only the navigation options (bread crumbs and local sub menus) differ due to different placement in navigation hierarchy.
 
 ```html
-<iframe title="Contact us" src="../test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
+<iframe title="Contact us" src="/test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
 
-<iframe title="Contact us" src="../test-assets/iframe-unique-name-4b1c6c/sub-dir/page-one.html"> </iframe>
+<iframe title="Contact us" src="/test-assets/iframe-unique-name-4b1c6c/sub-dir/page-one.html"> </iframe>
 ```
 
 #### Passed Example 5
@@ -94,9 +94,9 @@ Multiple `iframe` within document tree have the same [accessible name][] (given 
 Multiple `iframe` within document tree have the same [accessible name][] (given by `title`) and embed equivalent ressources.
 
 ```html
-<iframe title="Contact us" src="../test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
+<iframe title="Contact us" src="/test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
 
-<iframe title="Contact us" src="../test-assets/iframe-unique-name-4b1c6c/page-one-copy.html"> </iframe>
+<iframe title="Contact us" src="/test-assets/iframe-unique-name-4b1c6c/page-one-copy.html"> </iframe>
 ```
 
 #### Passed Example 6
@@ -104,9 +104,9 @@ Multiple `iframe` within document tree have the same [accessible name][] (given 
 Multiple `iframe` within document tree have the same [accessible name][] (given by `title`) and embed the same resource. `src` attributes only differ due to trailing slashes, but resolves to the same resource after redirects caused by user agent.
 
 ```html
-<iframe title="Contact us" src="../test-assets/iframe-unique-name-4b1c6c/sub-dir-2/"> </iframe>
+<iframe title="Contact us" src="/test-assets/iframe-unique-name-4b1c6c/sub-dir-2/"> </iframe>
 
-<iframe title="Contact us" src="../test-assets/iframe-unique-name-4b1c6c/sub-dir-2"> </iframe>
+<iframe title="Contact us" src="/test-assets/iframe-unique-name-4b1c6c/sub-dir-2"> </iframe>
 ```
 
 #### Passed Example 7
@@ -114,9 +114,9 @@ Multiple `iframe` within document tree have the same [accessible name][] (given 
 Multiple `iframe` within document tree have the same [accessible name][] (given by `title`) and embed equivalent ressources. Ressources differ by the amount of information available and/or a differently worded information.
 
 ```html
-<iframe title="Contact us" src="../test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
+<iframe title="Contact us" src="/test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
 
-<iframe title="Contact us" src="../test-assets/iframe-unique-name-4b1c6c/page-three-same-as-page-one.html"> </iframe>
+<iframe title="Contact us" src="/test-assets/iframe-unique-name-4b1c6c/page-three-same-as-page-one.html"> </iframe>
 ```
 
 #### Passed Example 8
@@ -124,9 +124,9 @@ Multiple `iframe` within document tree have the same [accessible name][] (given 
 Multiple `iframe` within document tree have the same [accessible name][] (given by `title`) and embed equivalent ressources. Each `iframe` refers to a different url that referenced different advertising content (giving by a third party) but embed ressources has equivalent purpose: showing an advertising.
 
 ```html
-<iframe title="advertising" src="../test-assets/iframe-unique-name-4b1c6c/advertising-one.html"> </iframe>
+<iframe title="advertising" src="/test-assets/iframe-unique-name-4b1c6c/advertising-one.html"> </iframe>
 
-<iframe title="advertising" src="../test-assets/iframe-unique-name-4b1c6c/advertising-two.html"> </iframe>
+<iframe title="advertising" src="/test-assets/iframe-unique-name-4b1c6c/advertising-two.html"> </iframe>
 ```
 
 ### Failed
@@ -136,9 +136,9 @@ Multiple `iframe` within document tree have the same [accessible name][] (given 
 Multiple `iframe` elements have the same [accessible name][] (given by `title`) but don't embed equivalent ressources.
 
 ```html
-<iframe title="List of Contributors" src="../test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
+<iframe title="List of Contributors" src="/test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
 
-<iframe title="List of Contributors" src="../test-assets/iframe-unique-name-4b1c6c/page-two.html"> </iframe>
+<iframe title="List of Contributors" src="/test-assets/iframe-unique-name-4b1c6c/page-two.html"> </iframe>
 ```
 
 #### Failed Example 2
@@ -146,9 +146,9 @@ Multiple `iframe` elements have the same [accessible name][] (given by `title`) 
 Multiple `iframe` elements have the same [accessible name][] (given by `aria-label`) but don't embed equivalent ressources.
 
 ```html
-<iframe aria-label="List of Contributors" src="../test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
+<iframe aria-label="List of Contributors" src="/test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
 
-<iframe aria-label="List of Contributors" src="../test-assets/iframe-unique-name-4b1c6c/page-two.html"> </iframe>
+<iframe aria-label="List of Contributors" src="/test-assets/iframe-unique-name-4b1c6c/page-two.html"> </iframe>
 ```
 
 #### Failed Example 3
@@ -156,9 +156,9 @@ Multiple `iframe` elements have the same [accessible name][] (given by `aria-lab
 Multiple `iframe` elements have the same [accessible name][] (given by `title` and `aria-label`) but don't embed equivalent ressources.
 
 ```html
-<iframe title="List of Contributors" src="../test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
+<iframe title="List of Contributors" src="/test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
 
-<iframe aria-label="List of Contributors" src="../test-assets/iframe-unique-name-4b1c6c/page-two.html"> </iframe>
+<iframe aria-label="List of Contributors" src="/test-assets/iframe-unique-name-4b1c6c/page-two.html"> </iframe>
 ```
 
 ### Inapplicable
@@ -168,7 +168,7 @@ Multiple `iframe` elements have the same [accessible name][] (given by `title` a
 Usage of `title` attribute to describe the `iframe` content, and there is only one iframe within document tree.
 
 ```html
-<iframe title="List of Contributors" src="../test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
+<iframe title="List of Contributors" src="/test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
 ```
 
 #### Inapplicable Example 2
@@ -176,10 +176,10 @@ Usage of `title` attribute to describe the `iframe` content, and there is only o
 Multiple `iframe` elements in the document having different `title` descriptions as [accessible name][].
 
 ```html
-<iframe title="List of Contributors to Repository 1" src="../test-assets/iframe-unique-name-4b1c6c/page-one.html">
+<iframe title="List of Contributors to Repository 1" src="/test-assets/iframe-unique-name-4b1c6c/page-one.html">
 </iframe>
 
-<iframe title="List of Contributors to Repository 2" src="../test-assets/iframe-unique-name-4b1c6c/page-two.html">
+<iframe title="List of Contributors to Repository 2" src="/test-assets/iframe-unique-name-4b1c6c/page-two.html">
 </iframe>
 ```
 
@@ -188,10 +188,10 @@ Multiple `iframe` elements in the document having different `title` descriptions
 Multiple `iframe` elements in the document having different `aria-label` descriptions as [accessible name][].
 
 ```html
-<iframe aria-label="List of Contributors to Repository 1" src="../test-assets/iframe-unique-name-4b1c6c/page-one.html">
+<iframe aria-label="List of Contributors to Repository 1" src="/test-assets/iframe-unique-name-4b1c6c/page-one.html">
 </iframe>
 
-<iframe aria-label="List of Contributors to Repository 2" src="../test-assets/iframe-unique-name-4b1c6c/page-two.html">
+<iframe aria-label="List of Contributors to Repository 2" src="/test-assets/iframe-unique-name-4b1c6c/page-two.html">
 </iframe>
 ```
 
@@ -201,10 +201,10 @@ Multiple `iframe` elements in the document having different `aria-labelledby` de
 
 ```html
 <div id="desc-for-title">List of Contributors</div>
-<iframe aria-labelledby="desc-for-title" src="../test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
+<iframe aria-labelledby="desc-for-title" src="/test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
 
 <div id="desc-for-title1">List of Reviewers</div>
-<iframe aria-labelledby="desc-for-title1" src="../test-assets/iframe-unique-name-4b1c6c/page-two.html"> </iframe>
+<iframe aria-labelledby="desc-for-title1" src="/test-assets/iframe-unique-name-4b1c6c/page-two.html"> </iframe>
 ```
 
 #### Inapplicable Example 5
@@ -212,10 +212,10 @@ Multiple `iframe` elements in the document having different `aria-labelledby` de
 `iframe` having the same `title` within a given document tree, but one of them is not [included in the accessibility tree][].
 
 ```html
-<iframe aria-hidden="true" title="List of Contributors" src="../test-assets/iframe-unique-name-4b1c6c/page-one.html">
+<iframe aria-hidden="true" title="List of Contributors" src="/test-assets/iframe-unique-name-4b1c6c/page-one.html">
 </iframe>
 
-<iframe title="List of Contributors" src="../test-assets/iframe-unique-name-4b1c6c/page-two.html"> </iframe>
+<iframe title="List of Contributors" src="/test-assets/iframe-unique-name-4b1c6c/page-two.html"> </iframe>
 ```
 
 #### Inapplicable Example 6
@@ -223,17 +223,17 @@ Multiple `iframe` elements in the document having different `aria-labelledby` de
 `iframe` are allowed to have the same `title` across different document trees. In this example `iframe` with `id` `level2-frame1` has a parent document tree of `iframe` with `id` `level1-frame2`, and does not share the document tree of `iframe` with `id` `level1-frame1`.
 
 ```html
-<iframe id="level1-frame1" title="List of Contributors" src="../test-assets/iframe-unique-name-4b1c6c/page-one.html">
+<iframe id="level1-frame1" title="List of Contributors" src="/test-assets/iframe-unique-name-4b1c6c/page-one.html">
 </iframe>
 <iframe
 	id="level1-frame2"
 	title="List of Contributors 2"
-	src="../test-assets/iframe-unique-name-4b1c6c/page-with-iframe.html"
+	src="/test-assets/iframe-unique-name-4b1c6c/page-with-iframe.html"
 >
 	<!--
   Content of document includes an iframe:
   
-  <iframe id="level2-frame1" title="List of Contributors" src="../test-assets/iframe-unique-name-4b1c6c/page-one.html">
+  <iframe id="level2-frame1" title="List of Contributors" src="/test-assets/iframe-unique-name-4b1c6c/page-one.html">
   </iframe>
   -->
 </iframe>
@@ -244,7 +244,7 @@ Multiple `iframe` elements in the document having different `aria-labelledby` de
 `alt` cannot be used to provide [accessible name][] for iframe.
 
 ```html
-<iframe alt="Some" src="../test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
+<iframe alt="Some" src="/test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
 ```
 
 #### Inapplicable Example 8
@@ -252,9 +252,9 @@ Multiple `iframe` elements in the document having different `aria-labelledby` de
 Does not apply to `object` elements.
 
 ```html
-<object title="List of Contributors" src="../test-assets/iframe-unique-name-4b1c6c/page-one.html"> </object>
+<object title="List of Contributors" src="/test-assets/iframe-unique-name-4b1c6c/page-one.html"> </object>
 
-<object aria-label="List of Contributors Clone" src="../test-assets/iframe-unique-name-4b1c6c/page-two.html"> </object>
+<object aria-label="List of Contributors Clone" src="/test-assets/iframe-unique-name-4b1c6c/page-two.html"> </object>
 ```
 
 #### Inapplicable Example 9
@@ -262,9 +262,9 @@ Does not apply to `object` elements.
 No [accessible name][] is provided
 
 ```html
-<iframe src="../test-assets/iframe-unique-name-4b1c6c/page-two.html"> </iframe>
+<iframe src="/test-assets/iframe-unique-name-4b1c6c/page-two.html"> </iframe>
 
-<iframe src="../test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
+<iframe src="/test-assets/iframe-unique-name-4b1c6c/page-one.html"> </iframe>
 ```
 
 #### Inapplicable Example 10
@@ -272,10 +272,10 @@ No [accessible name][] is provided
 Does not apply to `iframe` elements that are not [included in the accessibility tree][], via `display:none`.
 
 ```html
-<iframe style="display:none;" title="Document One" src="../test-assets/iframe-unique-name-4b1c6c/page-one.html">
+<iframe style="display:none;" title="Document One" src="/test-assets/iframe-unique-name-4b1c6c/page-one.html">
 </iframe>
 
-<iframe style="display:none;" aria-label="Document One" src="../test-assets/iframe-unique-name-4b1c6c/page-two.html">
+<iframe style="display:none;" aria-label="Document One" src="/test-assets/iframe-unique-name-4b1c6c/page-two.html">
 </iframe>
 ```
 

--- a/_rules/video-audio-described-1ea59c.md
+++ b/_rules/video-audio-described-1ea59c.md
@@ -48,8 +48,8 @@ A video element with a voiceover that describes the visual information.
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/video-with-voiceover.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video-with-voiceover.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/video-with-voiceover.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video-with-voiceover.webm" type="video/webm" />
 </video>
 ```
 
@@ -65,10 +65,10 @@ A video element with an audio description.
 <figure id="ozplayer-1-container" class="ozplayer-container">
 	<div data-controls="stack" class="ozplayer" id="ozplayer-1">
 		<video controls="controls" preload="none">
-			<source src="../test-assets/rabbit-video.mp4" type="video/mp4" />
+			<source src="/test-assets/rabbit-video.mp4" type="video/mp4" />
 		</video>
 		<audio data-default="default" preload="none">
-			<source src="../test-assets/rabbit-video/audio-description.mp3" type="audio/mp3" />
+			<source src="/test-assets/rabbit-video/audio-description.mp3" type="audio/mp3" />
 		</audio>
 	</div>
 </figure>
@@ -89,8 +89,8 @@ A video element without an audio description.
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/video.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video.webm" type="video/webm" />
 </video>
 ```
 
@@ -100,8 +100,8 @@ A video element with an incorrect audio description.
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/video-with-incorrect-voiceover.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video-with-incorrect-voiceover.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/video-with-incorrect-voiceover.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video-with-incorrect-voiceover.webm" type="video/webm" />
 </video>
 ```
 
@@ -117,10 +117,10 @@ A video element with an incorrect audio description.
 <figure id="ozplayer-1-container" class="ozplayer-container">
 	<div data-controls="stack" class="ozplayer" id="ozplayer-1">
 		<video controls="controls" preload="none">
-			<source src="../test-assets/rabbit-video/video.mp4" type="video/mp4" />
+			<source src="/test-assets/rabbit-video/video.mp4" type="video/mp4" />
 		</video>
 		<audio data-default="default" preload="none">
-			<source src="../test-assets/rabbit-video/incorrect-audio-description.mp3" type="audio/mp3" />
+			<source src="/test-assets/rabbit-video/incorrect-audio-description.mp3" type="audio/mp3" />
 		</audio>
 	</div>
 </figure>
@@ -141,8 +141,8 @@ A video element without audio.
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/silent.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/silent.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/silent.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/silent.webm" type="video/webm" />
 </video>
 ```
 
@@ -152,8 +152,8 @@ A video element that is not [visible][].
 
 ```html
 <video controls style="display: none;">
-	<source src="../test-assets/rabbit-video/video.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video.webm" type="video/webm" />
 </video>
 ```
 

--- a/_rules/video-description-track-f196ce.md
+++ b/_rules/video-description-track-f196ce.md
@@ -52,9 +52,9 @@ A video element with a track element that contains descriptions.
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/video.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video.webm" type="video/webm" />
-	<track kind="descriptions" src="../test-assets/rabbit-video/descriptions.vtt" />
+	<source src="/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video.webm" type="video/webm" />
+	<track kind="descriptions" src="/test-assets/rabbit-video/descriptions.vtt" />
 </video>
 ```
 
@@ -66,9 +66,9 @@ A video element with a track element that contains incorrect descriptions.
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/video.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video.webm" type="video/webm" />
-	<track kind="descriptions" src="../test-assets/rabbit-video/incorrect-descriptions.vtt" />
+	<source src="/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video.webm" type="video/webm" />
+	<track kind="descriptions" src="/test-assets/rabbit-video/incorrect-descriptions.vtt" />
 </video>
 ```
 
@@ -80,8 +80,8 @@ A video element without a track element.
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/video.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video.webm" type="video/webm" />
 </video>
 ```
 
@@ -91,9 +91,9 @@ A video element that is not [visible][].
 
 ```html
 <video controls style="display: none;">
-	<source src="../test-assets/rabbit-video/video.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video.webm" type="video/webm" />
-	<track kind="descriptions" src="../test-assets/rabbit-video/descriptions.vtt" />
+	<source src="/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video.webm" type="video/webm" />
+	<track kind="descriptions" src="/test-assets/rabbit-video/descriptions.vtt" />
 </video>
 ```
 
@@ -103,9 +103,9 @@ A video element without audio.
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/silent.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/silent.webm" type="video/webm" />
-	<track kind="descriptions" src="../test-assets/rabbit-video/descriptions.vtt" />
+	<source src="/test-assets/rabbit-video/silent.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/silent.webm" type="video/webm" />
+	<track kind="descriptions" src="/test-assets/rabbit-video/descriptions.vtt" />
 </video>
 ```
 

--- a/_rules/video-has-audio-alternative-eac66b.md
+++ b/_rules/video-has-audio-alternative-eac66b.md
@@ -53,7 +53,7 @@ There are no major accessibility support issues known for this rule.
 A video element with an associated track element that contains captions for all the audio.
 
 ```html
-<video src="../test-assets/perspective-video/perspective-video.mp4" controls>
+<video src="/test-assets/perspective-video/perspective-video.mp4" controls>
 	<track src="/test-assets/perspective-video/perspective-caption.vtt" kind="captions" />
 </video>
 ```
@@ -68,7 +68,7 @@ A video element that describes some of the text on the same page. The text on th
 	to navigate websites. Either through preference or circumstance. This is solved by keyboard compatibility. Keyboard
 	compatibility is described in WCAG. See the video below to watch the same information again in video form.
 </p>
-<video src="../test-assets/perspective-video/perspective-video.mp4" controls></video>
+<video src="/test-assets/perspective-video/perspective-video.mp4" controls></video>
 ```
 
 ### Failed
@@ -78,7 +78,7 @@ A video element that describes some of the text on the same page. The text on th
 A video element without any form of captions.
 
 ```html
-<video src="../test-assets/perspective-video/perspective-video.mp4" controls></video>
+<video src="/test-assets/perspective-video/perspective-video.mp4" controls></video>
 ```
 
 #### Failed Example 2
@@ -91,7 +91,7 @@ A video element that describes some of the text on the same page. The video cont
 	circumstance. This is solved by keyboard compatibility. Keyboard compatibility is described in WCAG. See the video
 	below to watch the same information again in video form.
 </p>
-<video src="../test-assets/perspective-video/perspective-video.mp4" controls></video>
+<video src="/test-assets/perspective-video/perspective-video.mp4" controls></video>
 ```
 
 ### Inapplicable
@@ -101,7 +101,7 @@ A video element that describes some of the text on the same page. The video cont
 A video element without that is not [visible][].
 
 ```html
-<video src="../test-assets/perspective-video/perspective-video.mp4" controls style="display: none;"></video>
+<video src="/test-assets/perspective-video/perspective-video.mp4" controls style="display: none;"></video>
 ```
 
 #### Inapplicable Example 2
@@ -109,7 +109,7 @@ A video element without that is not [visible][].
 A video element without audio.
 
 ```html
-<video src="../test-assets/perspective-video/perspective-video-silent.mp4" controls></video>
+<video src="/test-assets/perspective-video/perspective-video-silent.mp4" controls></video>
 ```
 
 [visible]: #visible 'Definition of visible'

--- a/_rules/video-has-captions-f51b46.md
+++ b/_rules/video-has-captions-f51b46.md
@@ -49,7 +49,7 @@ There are no major accessibility support issues known for this rule.
 A video element that has captions for all the audio baked into it.
 
 ```html
-<video src="../test-assets/perspective-video/perspective-video-with-captions.mp4" controls></video>
+<video src="/test-assets/perspective-video/perspective-video-with-captions.mp4" controls></video>
 ```
 
 #### Passed Example 2
@@ -57,7 +57,7 @@ A video element that has captions for all the audio baked into it.
 A video element with an associated track element that contain captions for all the audio.
 
 ```html
-<video src="../test-assets/perspective-video/perspective-video.mp4" controls>
+<video src="/test-assets/perspective-video/perspective-video.mp4" controls>
 	<track src="/test-assets/perspective-video/perspective-caption.vtt" kind="captions" />
 </video>
 ```
@@ -69,7 +69,7 @@ A video element with an associated track element that contain captions for all t
 A video element without any form of captions.
 
 ```html
-<video src="../test-assets/perspective-video/perspective-video.mp4" controls></video>
+<video src="/test-assets/perspective-video/perspective-video.mp4" controls></video>
 ```
 
 #### Failed Example 2
@@ -77,7 +77,7 @@ A video element without any form of captions.
 A video element with an associated track element that contain incorrect captions.
 
 ```html
-<video src="../test-assets/perspective-video/perspective-video.mp4" controls>
+<video src="/test-assets/perspective-video/perspective-video.mp4" controls>
 	<track src="/test-assets/perspective-video/perspective-incorrect-caption.vtt" kind="captions" />
 </video>
 ```
@@ -92,7 +92,7 @@ A video element with a text on the same page that described the audio in the vid
 	perspectives. Keyboard compatibility. Not being able to use your computer because your mouse doesn't work, is
 	frustrating. Many people use only the keyboard to navigate websites. Either through preference or circumstance.
 </p>
-<video src="../test-assets/perspective-video/perspective-video.mp4" controls></video>
+<video src="/test-assets/perspective-video/perspective-video.mp4" controls></video>
 ```
 
 #### Failed Example 4
@@ -105,7 +105,7 @@ A video element with an explicitly associated text on the same page that describ
 	perspectives. Keyboard compatibility. Not being able to use your computer because your mouse doesn't work, is
 	frustrating. Many people use only the keyboard to navigate websites. Either through preference or circumstance.
 </p>
-<video src="../test-assets/perspective-video/perspective-video.mp4" controls ariadescribedby="text"></video>
+<video src="/test-assets/perspective-video/perspective-video.mp4" controls ariadescribedby="text"></video>
 ```
 
 ### Inapplicable
@@ -115,7 +115,7 @@ A video element with an explicitly associated text on the same page that describ
 A video element without audio.
 
 ```html
-<video src="../test-assets/perspective-video/perspective-video-silent.mp4" controls></video>
+<video src="/test-assets/perspective-video/perspective-video-silent.mp4" controls></video>
 ```
 
 #### Inapplicable Example 2
@@ -123,7 +123,7 @@ A video element without audio.
 A video element that is not [visible][].
 
 ```html
-<video src="../test-assets/perspective-video/perspective-video.mp4" controls style="display: none;"></video>
+<video src="/test-assets/perspective-video/perspective-video.mp4" controls style="display: none;"></video>
 ```
 
 [visible]: #visible 'Definition of visible'

--- a/_rules/video-media-alternative-ab4d13.md
+++ b/_rules/video-media-alternative-ab4d13.md
@@ -57,7 +57,7 @@ A video element that describes some of the text on the same page. The text on th
 	to navigate websites. Either through preference or circumstance. This is solved by keyboard compatibility. Keyboard
 	compatibility is described in WCAG. See the video below to watch the same information again in video form.
 </p>
-<video src="../test-assets/perspective-video/perspective-video.mp4" controls></video>
+<video src="/test-assets/perspective-video/perspective-video.mp4" controls></video>
 ```
 
 ### Failed
@@ -72,7 +72,7 @@ A video element that describes some of the text on the same page. The video cont
 	circumstance. This is solved by keyboard compatibility. Keyboard compatibility is described in WCAG. See the video
 	below to watch the same information again in video form.
 </p>
-<video src="../test-assets/perspective-video/perspective-video.mp4" controls></video>
+<video src="/test-assets/perspective-video/perspective-video.mp4" controls></video>
 ```
 
 #### Failed Example 2
@@ -85,7 +85,7 @@ A video element that describes some of the text on the same page. The text is no
 	to navigate websites. Either through preference or circumstance. This is solved by keyboard compatibility. Keyboard
 	compatibility is described in WCAG. See the video below to watch the same information again in video form.
 </p>
-<video src="../test-assets/perspective-video/perspective-video.mp4" controls></video>
+<video src="/test-assets/perspective-video/perspective-video.mp4" controls></video>
 ```
 
 #### Failed Example 3
@@ -98,7 +98,7 @@ A video element that describes some of the text on the same page. The text on th
 	to navigate websites. Either through preference or circumstance. This is solved by keyboard compatibility. Keyboard
 	compatibility is described in WCAG.
 </p>
-<video src="../test-assets/perspective-video/perspective-video.mp4" controls></video>
+<video src="/test-assets/perspective-video/perspective-video.mp4" controls></video>
 ```
 
 #### Failed Example 4
@@ -114,7 +114,7 @@ A video element that describes some of the text on the same page. The text on th
 <p style="display: none;">
 	See the video below to watch the same information again in video form.
 </p>
-<video src="../test-assets/perspective-video/perspective-video.mp4" controls></video>
+<video src="/test-assets/perspective-video/perspective-video.mp4" controls></video>
 ```
 
 ### Inapplicable
@@ -129,7 +129,7 @@ A video element without audio. The text on the page labels the video as an alter
 	to navigate websites. Either through preference or circumstance. This is solved by keyboard compatibility. Keyboard
 	compatibility is described in WCAG. See the video below to watch the same information again in video form.
 </p>
-<video src="../test-assets/perspective-video/perspective-video-silent.mp4" controls></video>
+<video src="/test-assets/perspective-video/perspective-video-silent.mp4" controls></video>
 ```
 
 #### Inapplicable Example 2
@@ -142,7 +142,7 @@ A video element that describes some of the text on the same page. The text on th
 	to navigate websites. Either through preference or circumstance. This is solved by keyboard compatibility. Keyboard
 	compatibility is described in WCAG. See the video below to watch the same information again in video form.
 </p>
-<video src="../test-assets/perspective-video/perspective-video.mp4" controls style="display: none;"></video>
+<video src="/test-assets/perspective-video/perspective-video.mp4" controls style="display: none;"></video>
 ```
 
 [included in the accessibility tree]: #included-in-the-accessibility-tree 'Definition of included in the accessibility tree'

--- a/_rules/video-only-alternative-c3232f.md
+++ b/_rules/video-only-alternative-c3232f.md
@@ -68,7 +68,7 @@ A video element without audio. The text on the page labels the video as an alter
 </p>
 <video
 	data-rule-target
-	src="../test-assets/perspective-video/perspective-video-with-captions-silent.mp4"
+	src="/test-assets/perspective-video/perspective-video-with-captions-silent.mp4"
 	controls
 ></video>
 ```
@@ -79,8 +79,8 @@ A video only element with a track element that contains descriptions.
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/silent.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/silent.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/silent.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/silent.webm" type="video/webm" />
 	<track kind="descriptions" src="rabbit-video-descriptions.vtt" />
 </video>
 ```
@@ -91,8 +91,8 @@ A silent video element with a text transcript on the same page.
 
 ```html
 <video controls data-rule-target>
-  <source src="../test-assets/rabbit-video/silent.mp4" type="video/mp4"></source>
-  <source src="../test-assets/rabbit-video/silent.webm" type="video/webm"></source>
+  <source src="/test-assets/rabbit-video/silent.mp4" type="video/mp4"></source>
+  <source src="/test-assets/rabbit-video/silent.webm" type="video/webm"></source>
 </video>
 <p>The above video shows a giant fat rabbit climbing out of a hole in the ground.
 He stretches, yaws, and then starts walking.
@@ -105,12 +105,12 @@ A video element without audio has a separate audio track that describes the visu
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/silent.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/silent.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/silent.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/silent.webm" type="video/webm" />
 </video>
 
 <audio controls>
-	<source src="../test-assets/rabbit-video/audio-description.mp3" type="audio/mpeg" />
+	<source src="/test-assets/rabbit-video/audio-description.mp3" type="audio/mpeg" />
 </audio>
 ```
 
@@ -128,7 +128,7 @@ A video element that describes some of the text on the same page. The text on th
 </p>
 <video
 	data-rule-target
-	src="../test-assets/perspective-video/perspective-video-with-captions-silent.mp4"
+	src="/test-assets/perspective-video/perspective-video-with-captions-silent.mp4"
 	controls
 ></video>
 ```
@@ -139,8 +139,8 @@ A video only element with a track element that contains incorrect descriptions.
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/silent.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/silent.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/silent.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/silent.webm" type="video/webm" />
 	<track kind="descriptions" src="rabbit-video-incorrect-descriptions.vtt" />
 </video>
 ```
@@ -151,8 +151,8 @@ A silent video element with a link to an incorrect text transcript on a differen
 
 ```html
 <video controls data-rule-target>
-  <source src="../test-assets/rabbit-video/silent.mp4" type="video/mp4"></source>
-  <source src="../test-assets/rabbit-video/silent.webm" type="video/webm"></source>
+  <source src="/test-assets/rabbit-video/silent.mp4" type="video/mp4"></source>
+  <source src="/test-assets/rabbit-video/silent.webm" type="video/webm"></source>
 </video>
 <a href="/test-assets/rabbit-video-incorrect-transcript.html">Transcript</a>
 ```
@@ -163,12 +163,12 @@ A video element without audio has a separate audio track that incorrectly descri
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/silent.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/silent.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/silent.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/silent.webm" type="video/webm" />
 </video>
 
 <audio controls>
-	<source src="../test-assets/rabbit-video/incorrect-audio-description.mp3" type="audio/mpeg" />
+	<source src="/test-assets/rabbit-video/incorrect-audio-description.mp3" type="audio/mpeg" />
 </audio>
 ```
 
@@ -184,7 +184,7 @@ A video element with audio.
 	to navigate websites. Either through preference or circumstance. This is solved by keyboard compatibility. Keyboard
 	compatibility is described in WCAG. See the video below to watch the same information again in video form.
 </p>
-<video data-rule-target src="../test-assets/perspective-video/perspective-video.mp4" controls></video>
+<video data-rule-target src="/test-assets/perspective-video/perspective-video.mp4" controls></video>
 ```
 
 #### Inapplicable Example 2
@@ -193,8 +193,8 @@ A video only element that is not [visible][].
 
 ```html
 <video controls style="display: none;">
-	<source src="../test-assets/rabbit-video/silent.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/silent.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/silent.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/silent.webm" type="video/webm" />
 	<track kind="descriptions" src="rabbit-video-descriptions.vtt" />
 </video>
 ```

--- a/_rules/video-only-audio-alternative-d7ba54.md
+++ b/_rules/video-only-audio-alternative-d7ba54.md
@@ -45,12 +45,12 @@ A video element without audio has a separate audio track that describes the visu
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/silent.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/silent.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/silent.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/silent.webm" type="video/webm" />
 </video>
 
 <audio controls>
-	<source src="../test-assets/rabbit-video/audio-description.mp3" type="audio/mpeg" />
+	<source src="/test-assets/rabbit-video/audio-description.mp3" type="audio/mpeg" />
 </audio>
 ```
 
@@ -62,8 +62,8 @@ A video element without an audio track.
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/silent.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/silent.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/silent.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/silent.webm" type="video/webm" />
 </video>
 ```
 
@@ -73,12 +73,12 @@ A video element without audio has a separate audio track that incorrectly descri
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/silent.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/silent.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/silent.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/silent.webm" type="video/webm" />
 </video>
 
 <audio controls>
-	<source src="../test-assets/rabbit-video/incorrect-audio-description.mp3" type="audio/mpeg" />
+	<source src="/test-assets/rabbit-video/incorrect-audio-description.mp3" type="audio/mpeg" />
 </audio>
 ```
 
@@ -90,8 +90,8 @@ A video element with audio.
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/video.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video.webm" type="video/webm" />
 </video>
 ```
 
@@ -101,8 +101,8 @@ A video element without sound that is not [visible][].
 
 ```html
 <video controls style="display: none;">
-	<source src="../test-assets/rabbit-video/silent.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/silent.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/silent.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/silent.webm" type="video/webm" />
 </video>
 ```
 

--- a/_rules/video-only-description-track-ac7dc6.md
+++ b/_rules/video-only-description-track-ac7dc6.md
@@ -48,8 +48,8 @@ A video only element with a track element that contains descriptions.
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/silent.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/silent.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/silent.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/silent.webm" type="video/webm" />
 	<track kind="descriptions" src="rabbit-video-descriptions.vtt" />
 </video>
 ```
@@ -62,8 +62,8 @@ A video only element with a track element that contains incorrect descriptions.
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/silent.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/silent.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/silent.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/silent.webm" type="video/webm" />
 	<track kind="descriptions" src="rabbit-video-incorrect-descriptions.vtt" />
 </video>
 ```
@@ -76,8 +76,8 @@ A video only element without a track element.
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/silent.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/silent.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/silent.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/silent.webm" type="video/webm" />
 </video>
 ```
 
@@ -87,8 +87,8 @@ A video only element that is not [visible][].
 
 ```html
 <video controls style="display: none;">
-	<source src="../test-assets/rabbit-video/silent.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/silent.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/silent.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/silent.webm" type="video/webm" />
 	<track kind="descriptions" src="rabbit-video-descriptions.vtt" />
 </video>
 ```
@@ -99,8 +99,8 @@ A video element with audio.
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/video.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video.webm" type="video/webm" />
 	<track kind="descriptions" src="rabbit-video-descriptions.vtt" />
 </video>
 ```

--- a/_rules/video-only-element-transcript-ee13b5.md
+++ b/_rules/video-only-element-transcript-ee13b5.md
@@ -52,8 +52,8 @@ A silent video element with a text transcript on the same page.
 
 ```html
 <video controls data-rule-target>
-  <source src="../test-assets/rabbit-video/silent.mp4" type="video/mp4"></source>
-  <source src="../test-assets/rabbit-video/silent.webm" type="video/webm"></source>
+  <source src="/test-assets/rabbit-video/silent.mp4" type="video/mp4"></source>
+  <source src="/test-assets/rabbit-video/silent.webm" type="video/webm"></source>
 </video>
 <p>The above video shows a giant fat rabbit climbing out of a hole in the ground.
 He stretches, yaws, and then starts walking.
@@ -66,8 +66,8 @@ A silent video element with a link to a text transcript on a different page.
 
 ```html
 <video controls data-rule-target>
-  <source src="../test-assets/rabbit-video/silent.mp4" type="video/mp4"></source>
-  <source src="../test-assets/rabbit-video/silent.webm" type="video/webm"></source>
+  <source src="/test-assets/rabbit-video/silent.mp4" type="video/mp4"></source>
+  <source src="/test-assets/rabbit-video/silent.webm" type="video/webm"></source>
 </video>
 <a href="/test-assets/rabbit-video-transcript.html">Transcript</a>
 ```
@@ -80,8 +80,8 @@ A silent video element with an incorrect text transcript on the same page.
 
 ```html
 <video controls data-rule-target>
-  <source src="../test-assets/rabbit-video/silent.mp4" type="video/mp4"></source>
-  <source src="../test-assets/rabbit-video/silent.webm" type="video/webm"></source>
+  <source src="/test-assets/rabbit-video/silent.mp4" type="video/mp4"></source>
+  <source src="/test-assets/rabbit-video/silent.webm" type="video/webm"></source>
 </video>
 <p>The above video shows a giant fat dog climbing out of a hole in the ground.
 He stretches, yaws, and then starts walking.
@@ -94,8 +94,8 @@ A silent video element with a link to an incorrect text transcript on a differen
 
 ```html
 <video controls data-rule-target>
-  <source src="../test-assets/rabbit-video/silent.mp4" type="video/mp4"></source>
-  <source src="../test-assets/rabbit-video/silent.webm" type="video/webm"></source>
+  <source src="/test-assets/rabbit-video/silent.mp4" type="video/mp4"></source>
+  <source src="/test-assets/rabbit-video/silent.webm" type="video/webm"></source>
 </video>
 <a href="/test-assets/rabbit-video-incorrect-transcript.html">Transcript</a>
 ```
@@ -106,8 +106,8 @@ A silent video element with an [non-visible][visible] text transcript on the sam
 
 ```html
 <video controls data-rule-target>
-  <source src="../test-assets/rabbit-video/silent.mp4" type="video/mp4"></source>
-  <source src="../test-assets/rabbit-video/silent.webm" type="video/webm"></source>
+  <source src="/test-assets/rabbit-video/silent.mp4" type="video/mp4"></source>
+  <source src="/test-assets/rabbit-video/silent.webm" type="video/webm"></source>
 </video>
 <p style="text-indent: -9999px;">The above video shows a giant fat rabbit climbing out of a hole in the ground.
 He stretches, yaws, and then starts walking.
@@ -120,8 +120,8 @@ A silent video element with a text transcript on the same page that is not [incl
 
 ```html
 <video controls data-rule-target>
-  <source src="../test-assets/rabbit-video/silent.mp4" type="video/mp4"></source>
-  <source src="../test-assets/rabbit-video/silent.webm" type="video/webm"></source>
+  <source src="/test-assets/rabbit-video/silent.mp4" type="video/mp4"></source>
+  <source src="/test-assets/rabbit-video/silent.webm" type="video/webm"></source>
 </video>
 <p aria-hidden="true">The above video shows a giant fat rabbit climbing out of a hole in the ground.
 He stretches, yaws, and then starts walking.
@@ -136,8 +136,8 @@ A silent video element that is not [visible][] on the page.
 
 ```html
 <video controls style="display: none;" data-rule-target>
-  <source src="../test-assets/rabbit-video/silent.mp4" type="video/mp4"></source>
-  <source src="../test-assets/rabbit-video/silent.webm" type="video/webm"></source>
+  <source src="/test-assets/rabbit-video/silent.mp4" type="video/mp4"></source>
+  <source src="/test-assets/rabbit-video/silent.webm" type="video/webm"></source>
 </video>
 <a href="/test-assets/rabbit-video-transcript.html">Transcript</a>
 ```
@@ -148,8 +148,8 @@ A video element with audio.
 
 ```html
 <video controls data-rule-target>
-  <source src="../test-assets/rabbit-video/video.mp4" type="video/mp4"></source>
-  <source src="../test-assets/rabbit-video/video.webm" type="video/webm"></source>
+  <source src="/test-assets/rabbit-video/video.mp4" type="video/mp4"></source>
+  <source src="/test-assets/rabbit-video/video.webm" type="video/webm"></source>
 </video>
 <a href="/test-assets/rabbit-video-transcript.html">Transcript</a>
 ```

--- a/_rules/video-only-media-alternative-fd26cf.md
+++ b/_rules/video-only-media-alternative-fd26cf.md
@@ -58,7 +58,7 @@ A video element without audio. The text on the page labels the video as an alter
 	to navigate websites. Either through preference or circumstance. This is solved by keyboard compatibility. Keyboard
 	compatibility is described in WCAG. See the video below to watch the same information again in video form.
 </p>
-<video src="../test-assets/perspective-video/perspective-video-with-captions-silent.mp4" controls></video>
+<video src="/test-assets/perspective-video/perspective-video-with-captions-silent.mp4" controls></video>
 ```
 
 ### Failed
@@ -73,7 +73,7 @@ A video element that describes some of the text on the same page. The video cont
 	circumstance. This is solved by keyboard compatibility. Keyboard compatibility is described in WCAG. See the video
 	below to watch the same information again in video form.
 </p>
-<video src="../test-assets/perspective-video/perspective-video-with-captions-silent.mp4" controls></video>
+<video src="/test-assets/perspective-video/perspective-video-with-captions-silent.mp4" controls></video>
 ```
 
 #### Failed Example 2
@@ -86,7 +86,7 @@ A video element that describes some of the text on the same page. The text is no
 	to navigate websites. Either through preference or circumstance. This is solved by keyboard compatibility. Keyboard
 	compatibility is described in WCAG. See the video below to watch the same information again in video form.
 </p>
-<video src="../test-assets/perspective-video/perspective-video-with-captions-silent.mp4" controls></video>
+<video src="/test-assets/perspective-video/perspective-video-with-captions-silent.mp4" controls></video>
 ```
 
 #### Failed Example 3
@@ -99,7 +99,7 @@ A video element that describes some of the text on the same page. The text on th
 	to navigate websites. Either through preference or circumstance. This is solved by keyboard compatibility. Keyboard
 	compatibility is described in WCAG.
 </p>
-<video src="../test-assets/perspective-video/perspective-video-with-captions-silent.mp4" controls></video>
+<video src="/test-assets/perspective-video/perspective-video-with-captions-silent.mp4" controls></video>
 ```
 
 #### Failed Example 4
@@ -115,7 +115,7 @@ A video element that describes some of the text on the same page. The text on th
 <p style="display: none;">
 	See the video below to watch the same information again in video form.
 </p>
-<video src="../test-assets/perspective-video/perspective-video-with-captions-silent.mp4" controls></video>
+<video src="/test-assets/perspective-video/perspective-video-with-captions-silent.mp4" controls></video>
 ```
 
 ### Inapplicable
@@ -130,7 +130,7 @@ A video element with audio.
 	to navigate websites. Either through preference or circumstance. This is solved by keyboard compatibility. Keyboard
 	compatibility is described in WCAG. See the video below to watch the same information again in video form.
 </p>
-<video src="../test-assets/perspective-video/perspective-video.mp4" controls></video>
+<video src="/test-assets/perspective-video/perspective-video.mp4" controls></video>
 ```
 
 #### Inapplicable Example 2
@@ -144,7 +144,7 @@ A video element that describes some of the text on the same page. The text on th
 	compatibility is described in WCAG. See the video below to watch the same information again in video form.
 </p>
 <video
-	src="../test-assets/perspective-video/perspective-video-with-captions-silent.mp4"
+	src="/test-assets/perspective-video/perspective-video-with-captions-silent.mp4"
 	controls
 	style="display: none;"
 ></video>

--- a/_rules/video-transcript-1a02b0.md
+++ b/_rules/video-transcript-1a02b0.md
@@ -60,8 +60,8 @@ A video element with a text transcript on the same page.
 
 ```html
 <video controls>
-  <source src="../test-assets/rabbit-video/video.mp4" type="video/mp4"></source>
-  <source src="../test-assets/rabbit-video/video.webm" type="video/webm"></source>
+  <source src="/test-assets/rabbit-video/video.mp4" type="video/mp4"></source>
+  <source src="/test-assets/rabbit-video/video.webm" type="video/webm"></source>
 </video>
 <p>The above video shows a giant fat rabbit climbing out of a hole in the ground.
 He stretches, yaws, and then starts walking.
@@ -74,10 +74,10 @@ A video element with a link to a text transcript on a different page.
 
 ```html
 <video controls>
-  <source src="../test-assets/rabbit-video/video.mp4" type="video/mp4"></source>
-  <source src="../test-assets/rabbit-video/video.webm" type="video/webm"></source>
+  <source src="/test-assets/rabbit-video/video.mp4" type="video/mp4"></source>
+  <source src="/test-assets/rabbit-video/video.webm" type="video/webm"></source>
 </video>
-<a href="../test-assets/rabbit-video/transcript.html">Transcript</a>
+<a href="/test-assets/rabbit-video/transcript.html">Transcript</a>
 ```
 
 ### Failed
@@ -88,8 +88,8 @@ A video element with an incorrect text transcript on the same page.
 
 ```html
 <video controls>
-  <source src="../test-assets/rabbit-video/video.mp4" type="video/mp4"></source>
-  <source src="../test-assets/rabbit-video/video.webm" type="video/webm"></source>
+  <source src="/test-assets/rabbit-video/video.mp4" type="video/mp4"></source>
+  <source src="/test-assets/rabbit-video/video.webm" type="video/webm"></source>
 </video>
 <p>The above video shows a giant fat dog climbing out of a hole in the ground.
 He stretches, yaws, and then starts walking.
@@ -102,10 +102,10 @@ A video element with a link to an incorrect text transcript on a different page.
 
 ```html
 <video controls>
-  <source src="../test-assets/rabbit-video/video.mp4" type="video/mp4"></source>
-  <source src="../test-assets/rabbit-video/video.webm" type="video/webm"></source>
+  <source src="/test-assets/rabbit-video/video.mp4" type="video/mp4"></source>
+  <source src="/test-assets/rabbit-video/video.webm" type="video/webm"></source>
 </video>
-<a href="../test-assets/rabbit-video/incorrect-transcript.html">Transcript</a>
+<a href="/test-assets/rabbit-video/incorrect-transcript.html">Transcript</a>
 ```
 
 ### Inapplicable
@@ -116,10 +116,10 @@ A video element that is not [visible][].
 
 ```html
 <video controls style="display: none;">
-  <source src="../test-assets/rabbit-video/video.mp4" type="video/mp4"></source>
-  <source src="../test-assets/rabbit-video/video.webm" type="video/webm"></source>
+  <source src="/test-assets/rabbit-video/video.mp4" type="video/mp4"></source>
+  <source src="/test-assets/rabbit-video/video.webm" type="video/webm"></source>
 </video>
-<a href="../test-assets/rabbit-video/transcript.html">Transcript</a>
+<a href="/test-assets/rabbit-video/transcript.html">Transcript</a>
 ```
 
 #### Inapplicable Example 2
@@ -128,10 +128,10 @@ A video element without audio.
 
 ```html
 <video controls>
-  <source src="../test-assets/rabbit-video/silent.mp4" type="video/mp4"></source>
-  <source src="../test-assets/rabbit-video/silent.webm" type="video/webm"></source>
+  <source src="/test-assets/rabbit-video/silent.mp4" type="video/mp4"></source>
+  <source src="/test-assets/rabbit-video/silent.webm" type="video/webm"></source>
 </video>
-<a href="../test-assets/rabbit-video/transcript.html">Transcript</a>
+<a href="/test-assets/rabbit-video/transcript.html">Transcript</a>
 ```
 
 [visible]: #visible 'Definition of visible'

--- a/_rules/video-with-audio-has-audio-description-1ec09b.md
+++ b/_rules/video-with-audio-has-audio-description-1ec09b.md
@@ -58,8 +58,8 @@ A video element with a voiceover that describes the visual information.
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/video-with-voiceover.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video-with-voiceover.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/video-with-voiceover.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video-with-voiceover.webm" type="video/webm" />
 </video>
 ```
 
@@ -69,9 +69,9 @@ A video element with a track element that contains descriptions.
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/video.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video.webm" type="video/webm" />
-	<track kind="descriptions" src="../test-assets/rabbit-video/descriptions.vtt" />
+	<source src="/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video.webm" type="video/webm" />
+	<track kind="descriptions" src="/test-assets/rabbit-video/descriptions.vtt" />
 </video>
 ```
 
@@ -85,7 +85,7 @@ A video element that describes some of the text on the same page. The text on th
 	to navigate websites. Either through preference or circumstance. This is solved by keyboard compatibility. Keyboard
 	compatibility is described in WCAG. See the video below to watch the same information again in video form.
 </p>
-<video src="../test-assets/perspective-video/perspective-video.mp4" controls></video>
+<video src="/test-assets/perspective-video/perspective-video.mp4" controls></video>
 ```
 
 ### Failed
@@ -96,8 +96,8 @@ A video element with an incorrect audio description.
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/video-with-incorrect-voiceover.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video-with-incorrect-voiceover.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/video-with-incorrect-voiceover.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video-with-incorrect-voiceover.webm" type="video/webm" />
 </video>
 ```
 
@@ -107,9 +107,9 @@ A video element with a track element that contains incorrect descriptions.
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/video.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video.webm" type="video/webm" />
-	<track kind="descriptions" src="../test-assets/rabbit-video/incorrect-descriptions.vtt" />
+	<source src="/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video.webm" type="video/webm" />
+	<track kind="descriptions" src="/test-assets/rabbit-video/incorrect-descriptions.vtt" />
 </video>
 ```
 
@@ -119,10 +119,10 @@ A video element with a link to a text transcript.
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/video.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video.webm" type="video/webm" />
 </video>
-<a href="../test-assets/rabbit-video/transcript.html">Transcript</a>
+<a href="/test-assets/rabbit-video/transcript.html">Transcript</a>
 ```
 
 ### Inapplicable
@@ -133,8 +133,8 @@ A video element without audio.
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/silent.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/silent.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/silent.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/silent.webm" type="video/webm" />
 </video>
 ```
 
@@ -144,8 +144,8 @@ A video element that is not [visible][].
 
 ```html
 <video controls style="display: none;">
-	<source src="../test-assets/rabbit-video/video.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video.webm" type="video/webm" />
 </video>
 ```
 

--- a/_rules/video-with-audio-has-description-or-transcript-c5a4ea.md
+++ b/_rules/video-with-audio-has-description-or-transcript-c5a4ea.md
@@ -62,8 +62,8 @@ A video element with a voiceover that describes the visual information.
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/video-with-voiceover.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video-with-voiceover.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/video-with-voiceover.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video-with-voiceover.webm" type="video/webm" />
 </video>
 ```
 
@@ -73,10 +73,10 @@ A video element with a link to a text transcript.
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/video.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video.webm" type="video/webm" />
 </video>
-<a href="../test-assets/rabbit-video/transcript.html">Transcript</a>
+<a href="/test-assets/rabbit-video/transcript.html">Transcript</a>
 ```
 
 #### Passed Example 3
@@ -85,9 +85,9 @@ A video element with a track element that contains descriptions.
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/video.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video.webm" type="video/webm" />
-	<track kind="descriptions" src="../test-assets/rabbit-video/descriptions.vtt" />
+	<source src="/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video.webm" type="video/webm" />
+	<track kind="descriptions" src="/test-assets/rabbit-video/descriptions.vtt" />
 </video>
 ```
 
@@ -101,7 +101,7 @@ A video element that describes some of the text on the same page. The text on th
 	to navigate websites. Either through preference or circumstance. This is solved by keyboard compatibility. Keyboard
 	compatibility is described in WCAG. See the video below to watch the same information again in video form.
 </p>
-<video src="../test-assets/perspective-video/perspective-video.mp4" controls></video>
+<video src="/test-assets/perspective-video/perspective-video.mp4" controls></video>
 ```
 
 ### Failed
@@ -112,8 +112,8 @@ A video element with an incorrect audio description.
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/video-with-incorrect-voiceover.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video-with-incorrect-voiceover.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/video-with-incorrect-voiceover.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video-with-incorrect-voiceover.webm" type="video/webm" />
 </video>
 ```
 
@@ -123,10 +123,10 @@ A video element with a link to an incorrect text transcript on a different page.
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/video.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video.webm" type="video/webm" />
 </video>
-<a href="../test-assets/rabbit-video/incorrect-transcript.html">Transcript</a>
+<a href="/test-assets/rabbit-video/incorrect-transcript.html">Transcript</a>
 ```
 
 #### Failed Example 3
@@ -135,9 +135,9 @@ A video element with a track element that contains incorrect descriptions.
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/video.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video.webm" type="video/webm" />
-	<track kind="descriptions" src="../test-assets/rabbit-video/incorrect-descriptions.vtt" />
+	<source src="/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video.webm" type="video/webm" />
+	<track kind="descriptions" src="/test-assets/rabbit-video/incorrect-descriptions.vtt" />
 </video>
 ```
 
@@ -151,7 +151,7 @@ A video element that describes some of the text on the same page. The video cont
 	circumstance. This is solved by keyboard compatibility. Keyboard compatibility is described in WCAG. See the video
 	below to watch the same information again in video form.
 </p>
-<video src="../test-assets/perspective-video/perspective-video.mp4" controls></video>
+<video src="/test-assets/perspective-video/perspective-video.mp4" controls></video>
 ```
 
 ### Inapplicable
@@ -162,8 +162,8 @@ A video element without audio.
 
 ```html
 <video controls>
-	<source src="../test-assets/rabbit-video/silent.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/silent.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/silent.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/silent.webm" type="video/webm" />
 </video>
 ```
 
@@ -173,8 +173,8 @@ A video element that is not [visible][].
 
 ```html
 <video controls style="display: none;">
-	<source src="../test-assets/rabbit-video/video.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video.webm" type="video/webm" />
 </video>
 ```
 

--- a/test-assets/iframe-unique-name-4b1c6c/page-with-iframe.html
+++ b/test-assets/iframe-unique-name-4b1c6c/page-with-iframe.html
@@ -1,2 +1,2 @@
-<iframe id="level2-frame1" title="List of Contributors" src="../test-assets/iframe-unique-name/page-one.html">
+<iframe id="level2-frame1" title="List of Contributors" src="/test-assets/iframe-unique-name/page-one.html">
 </iframe>


### PR DESCRIPTION
Currently, all references to test assets are broken as `../test-assets` should really be `../../test-assets` (example: https://act-rules.github.io/testcases/2779a5/a41f13266a8e5ed73446344769c53d272c272fb6.html). To fix this, I've made all test references root relative instead: `/test-assets`.