### PR TITLE
chore: remove gatsby-plugin-offline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2602,7 +2602,7 @@
 		},
 		"act-rules-implementation-alfa": {
 			"version": "git+https://git@github.com/act-rules/act-rules-implementation-alfa.git#06ca4d3280dd24b1795e184b44494ccd3413360b",
-			"from": "git+https://git@github.com/act-rules/act-rules-implementation-alfa.git#06ca4d3280dd24b1795e184b44494ccd3413360b"
+			"from": "git+https://git@github.com/act-rules/act-rules-implementation-alfa.git"
 		},
 		"act-rules-implementation-axe-core": {
 			"version": "git+https://git@github.com/act-rules/act-rules-implementation-axe-core.git#9678019359303b6b0f51a41c246acd581fb21aed",
@@ -3199,14 +3199,6 @@
 				}
 			}
 		},
-		"babel-extract-comments": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/babel-extract-comments/-/babel-extract-comments-1.0.0.tgz",
-			"integrity": "sha512-qWWzi4TlddohA91bFwgt6zO/J0X+io7Qp184Fw0m2JYRSTZnJbFR8+07KmzudHCZgOiKRCrjhylwv9Xd8gfhVQ==",
-			"requires": {
-				"babylon": "^6.18.0"
-			}
-		},
 		"babel-jest": {
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
@@ -3398,24 +3390,10 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
 			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
 		},
-		"babel-plugin-syntax-object-rest-spread": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
-		},
 		"babel-plugin-syntax-trailing-function-commas": {
 			"version": "7.0.0-beta.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz",
 			"integrity": "sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ=="
-		},
-		"babel-plugin-transform-object-rest-spread": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
-			"integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
-			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "^6.8.0",
-				"babel-runtime": "^6.26.0"
-			}
 		},
 		"babel-plugin-transform-react-remove-prop-types": {
 			"version": "0.4.24",
@@ -3508,11 +3486,6 @@
 					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
 				}
 			}
-		},
-		"babylon": {
-			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
 		},
 		"backo2": {
 			"version": "1.0.2",
@@ -9283,35 +9256,6 @@
 				}
 			}
 		},
-		"gatsby-plugin-offline": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/gatsby-plugin-offline/-/gatsby-plugin-offline-3.0.6.tgz",
-			"integrity": "sha512-pqGw/u3AWiBg9WX4VLhhv3gOrKnGnUXrqYNxQ3PPzURjX5vfsrrpL1i4fYEW4TAX1dbbJllkmN9ncde6TJF9Fw==",
-			"requires": {
-				"@babel/runtime": "^7.6.0",
-				"cheerio": "^1.0.0-rc.3",
-				"glob": "^7.1.4",
-				"idb-keyval": "^3.2.0",
-				"lodash": "^4.17.15",
-				"slash": "^3.0.0",
-				"workbox-build": "^4.3.1"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.6.0",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.0.tgz",
-					"integrity": "sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==",
-					"requires": {
-						"regenerator-runtime": "^0.13.2"
-					}
-				},
-				"slash": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
-				}
-			}
-		},
 		"gatsby-plugin-page-creator": {
 			"version": "2.1.17",
 			"resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.1.17.tgz",
@@ -9857,7 +9801,8 @@
 		"get-own-enumerable-property-symbols": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz",
-			"integrity": "sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg=="
+			"integrity": "sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg==",
+			"dev": true
 		},
 		"get-port": {
 			"version": "3.2.0",
@@ -11090,11 +11035,6 @@
 				}
 			}
 		},
-		"idb-keyval": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-3.2.0.tgz",
-			"integrity": "sha512-slx8Q6oywCCSfKgPgL0sEsXtPVnSbTLWpyiDcu6msHOyKOLari1TD1qocXVCft80umnkk3/Qqh3lwoFt8T/BPQ=="
-		},
 		"ieee754": {
 			"version": "1.1.13",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -11963,7 +11903,8 @@
 		"is-regexp": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-			"integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
+			"integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+			"dev": true
 		},
 		"is-relative": {
 			"version": "1.0.0",
@@ -15060,11 +15001,6 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
 			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
 		},
-		"lodash._reinterpolate": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
-		},
 		"lodash.clonedeep": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -15125,23 +15061,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
-		},
-		"lodash.template": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
-			"integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
-			"requires": {
-				"lodash._reinterpolate": "^3.0.0",
-				"lodash.templatesettings": "^4.0.0"
-			}
-		},
-		"lodash.templatesettings": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
-			"integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
-			"requires": {
-				"lodash._reinterpolate": "^3.0.0"
-			}
 		},
 		"lodash.throttle": {
 			"version": "4.1.1",
@@ -21063,6 +20982,7 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
 			"integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+			"dev": true,
 			"requires": {
 				"get-own-enumerable-property-symbols": "^3.0.0",
 				"is-obj": "^1.0.1",
@@ -21086,15 +21006,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
 			"integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI="
-		},
-		"strip-comments": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-1.0.2.tgz",
-			"integrity": "sha512-kL97alc47hoyIQSV165tTt9rG5dn4w1dNnBhOQ3bOU1Nc1hel09jnXANaHJ7vzHLd4Ju8kseDGzlev96pghLFw==",
-			"requires": {
-				"babel-extract-comments": "^1.0.0",
-				"babel-plugin-transform-object-rest-spread": "^6.26.0"
-			}
 		},
 		"strip-dirs": {
 			"version": "2.1.0",
@@ -23144,162 +23055,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
 			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
-		},
-		"workbox-background-sync": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-4.3.1.tgz",
-			"integrity": "sha512-1uFkvU8JXi7L7fCHVBEEnc3asPpiAL33kO495UMcD5+arew9IbKW2rV5lpzhoWcm/qhGB89YfO4PmB/0hQwPRg==",
-			"requires": {
-				"workbox-core": "^4.3.1"
-			}
-		},
-		"workbox-broadcast-update": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-4.3.1.tgz",
-			"integrity": "sha512-MTSfgzIljpKLTBPROo4IpKjESD86pPFlZwlvVG32Kb70hW+aob4Jxpblud8EhNb1/L5m43DUM4q7C+W6eQMMbA==",
-			"requires": {
-				"workbox-core": "^4.3.1"
-			}
-		},
-		"workbox-build": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-4.3.1.tgz",
-			"integrity": "sha512-UHdwrN3FrDvicM3AqJS/J07X0KXj67R8Cg0waq1MKEOqzo89ap6zh6LmaLnRAjpB+bDIz+7OlPye9iii9KBnxw==",
-			"requires": {
-				"@babel/runtime": "^7.3.4",
-				"@hapi/joi": "^15.0.0",
-				"common-tags": "^1.8.0",
-				"fs-extra": "^4.0.2",
-				"glob": "^7.1.3",
-				"lodash.template": "^4.4.0",
-				"pretty-bytes": "^5.1.0",
-				"stringify-object": "^3.3.0",
-				"strip-comments": "^1.0.2",
-				"workbox-background-sync": "^4.3.1",
-				"workbox-broadcast-update": "^4.3.1",
-				"workbox-cacheable-response": "^4.3.1",
-				"workbox-core": "^4.3.1",
-				"workbox-expiration": "^4.3.1",
-				"workbox-google-analytics": "^4.3.1",
-				"workbox-navigation-preload": "^4.3.1",
-				"workbox-precaching": "^4.3.1",
-				"workbox-range-requests": "^4.3.1",
-				"workbox-routing": "^4.3.1",
-				"workbox-strategies": "^4.3.1",
-				"workbox-streams": "^4.3.1",
-				"workbox-sw": "^4.3.1",
-				"workbox-window": "^4.3.1"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-					"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"pretty-bytes": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
-					"integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
-				}
-			}
-		},
-		"workbox-cacheable-response": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-4.3.1.tgz",
-			"integrity": "sha512-Rp5qlzm6z8IOvnQNkCdO9qrDgDpoPNguovs0H8C+wswLuPgSzSp9p2afb5maUt9R1uTIwOXrVQMmPfPypv+npw==",
-			"requires": {
-				"workbox-core": "^4.3.1"
-			}
-		},
-		"workbox-core": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-4.3.1.tgz",
-			"integrity": "sha512-I3C9jlLmMKPxAC1t0ExCq+QoAMd0vAAHULEgRZ7kieCdUd919n53WC0AfvokHNwqRhGn+tIIj7vcb5duCjs2Kg=="
-		},
-		"workbox-expiration": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-4.3.1.tgz",
-			"integrity": "sha512-vsJLhgQsQouv9m0rpbXubT5jw0jMQdjpkum0uT+d9tTwhXcEZks7qLfQ9dGSaufTD2eimxbUOJfWLbNQpIDMPw==",
-			"requires": {
-				"workbox-core": "^4.3.1"
-			}
-		},
-		"workbox-google-analytics": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-4.3.1.tgz",
-			"integrity": "sha512-xzCjAoKuOb55CBSwQrbyWBKqp35yg1vw9ohIlU2wTy06ZrYfJ8rKochb1MSGlnoBfXGWss3UPzxR5QL5guIFdg==",
-			"requires": {
-				"workbox-background-sync": "^4.3.1",
-				"workbox-core": "^4.3.1",
-				"workbox-routing": "^4.3.1",
-				"workbox-strategies": "^4.3.1"
-			}
-		},
-		"workbox-navigation-preload": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-4.3.1.tgz",
-			"integrity": "sha512-K076n3oFHYp16/C+F8CwrRqD25GitA6Rkd6+qAmLmMv1QHPI2jfDwYqrytOfKfYq42bYtW8Pr21ejZX7GvALOw==",
-			"requires": {
-				"workbox-core": "^4.3.1"
-			}
-		},
-		"workbox-precaching": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-4.3.1.tgz",
-			"integrity": "sha512-piSg/2csPoIi/vPpp48t1q5JLYjMkmg5gsXBQkh/QYapCdVwwmKlU9mHdmy52KsDGIjVaqEUMFvEzn2LRaigqQ==",
-			"requires": {
-				"workbox-core": "^4.3.1"
-			}
-		},
-		"workbox-range-requests": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-4.3.1.tgz",
-			"integrity": "sha512-S+HhL9+iTFypJZ/yQSl/x2Bf5pWnbXdd3j57xnb0V60FW1LVn9LRZkPtneODklzYuFZv7qK6riZ5BNyc0R0jZA==",
-			"requires": {
-				"workbox-core": "^4.3.1"
-			}
-		},
-		"workbox-routing": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-4.3.1.tgz",
-			"integrity": "sha512-FkbtrODA4Imsi0p7TW9u9MXuQ5P4pVs1sWHK4dJMMChVROsbEltuE79fBoIk/BCztvOJ7yUpErMKa4z3uQLX+g==",
-			"requires": {
-				"workbox-core": "^4.3.1"
-			}
-		},
-		"workbox-strategies": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-4.3.1.tgz",
-			"integrity": "sha512-F/+E57BmVG8dX6dCCopBlkDvvhg/zj6VDs0PigYwSN23L8hseSRwljrceU2WzTvk/+BSYICsWmRq5qHS2UYzhw==",
-			"requires": {
-				"workbox-core": "^4.3.1"
-			}
-		},
-		"workbox-streams": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-4.3.1.tgz",
-			"integrity": "sha512-4Kisis1f/y0ihf4l3u/+ndMkJkIT4/6UOacU3A4BwZSAC9pQ9vSvJpIi/WFGQRH/uPXvuVjF5c2RfIPQFSS2uA==",
-			"requires": {
-				"workbox-core": "^4.3.1"
-			}
-		},
-		"workbox-sw": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-4.3.1.tgz",
-			"integrity": "sha512-0jXdusCL2uC5gM3yYFT6QMBzKfBr2XTk0g5TPAV4y8IZDyVNDyj1a8uSXy3/XrvkVTmQvLN4O5k3JawGReXr9w=="
-		},
-		"workbox-window": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-4.3.1.tgz",
-			"integrity": "sha512-C5gWKh6I58w3GeSc0wp2Ne+rqVw8qwcmZnQGpjiek8A2wpbxSJb1FdCoQVO+jDJs35bFgo/WETgl1fqgsxN0Hg==",
-			"requires": {
-				"workbox-core": "^4.3.1"
-			}
 		},
 		"worker-farm": {
 			"version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
 		"gatsby": "^2.15.15",
 		"gatsby-image": "^2.2.19",
 		"gatsby-plugin-manifest": "^2.2.15",
-		"gatsby-plugin-offline": "^3.0.6",
 		"gatsby-plugin-prefetch-google-fonts": "^1.4.3",
 		"gatsby-plugin-react-helmet": "^3.1.6",
 		"gatsby-plugin-sass": "^2.1.14",


### PR DESCRIPTION
Noticed that `dependabot` bumped [`gatsby-plugin-offline`](https://www.gatsbyjs.org/packages/gatsby-plugin-offline/), which is never used. This PR removes the plugin.

Closes issue(s): 
- NA

----

## Pull Request Etiquette

### **When creating PR:**
- Make sure you requesting to **pull a branch** (right side) to the `develop` branch (left side).

### **After creating PR:**
- Add yourself (and co-authors) as "Assignees" for PR.
- Add label to indicate if it's a `Rule`, `Definition` or `Chore`.
- Close the issue that the PR resolves (and make sure the issue is referenced in the top of this comment)
- Optionally request feedback from anyone in particular by assigning them as "Reviewers".

## How to Review And Approve
- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines. 
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.