### PR TITLE
chore: remove chore logs from rule changelog

### DIFF
--- a/gatsby/get-node-data.js
+++ b/gatsby/get-node-data.js
@@ -33,10 +33,16 @@ const getNodeData = async options => {
 					date: '%ct',
 				},
 			})
+
+			/**
+			 * Ignore `chore` log items
+			 */
+			const logs = gitLog.filter(({ msg }) => !/^chore/i.test(msg))
+
 			return {
 				...defaults,
 				path,
-				changelog: JSON.stringify(gitLog),
+				changelog: JSON.stringify(logs),
 			}
 		default:
 			return {


### PR DESCRIPTION
We have a lot of `Chore:...`  change logs listed in the logs of a given rule. This change remove such logs from the listing.

Eg: see - https://act-rules.github.io/rules/5f99a7/changelog, after this change all the chore line items will not be listed.

Closes issue(s): 
- NA

----

## Pull Request Etiquette

### **When creating PR:**
- Make sure you requesting to **pull a branch** (right side) to the `develop` branch (left side).

### **After creating PR:**
- Add yourself (and co-authors) as "Assignees" for PR.
- Add label to indicate if it's a `Rule`, `Definition` or `Chore`.
- Close the issue that the PR resolves (and make sure the issue is referenced in the top of this comment)
- Optionally request feedback from anyone in particular by assigning them as "Reviewers".

## How to Review And Approve
- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines. 
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.