### PR TITLE
chore: set title-require html-hint test to off by default

### DIFF
--- a/_rules/__tests__/testcases.js
+++ b/_rules/__tests__/testcases.js
@@ -13,10 +13,10 @@ const htmlHintRules = {
 	'spec-char-escape': true,
 	'id-unique': true,
 	'src-not-empty': true,
-	'title-require': true,
 	'alt-require': true,
 	'attr-unsafe-chars': true,
 	// 'OFF'
+	'title-require': false,
 	'doctype-first': false,
 	'doctype-html5': false,
 	'attr-value-not-empty': false,

--- a/_rules/html-has-title-2779a5.md
+++ b/_rules/html-has-title-2779a5.md
@@ -18,10 +18,6 @@ authors:
   - Bryn Anderson
   - Anne Thyme Nørregaard
   - Jey Nandakumar
-htmlHintIgnore:
-  # https://www.npmjs.com/package/htmlhint
-  # (used with `npm test` to ensure validity of code snippets)
-  - 'title-require'
 ---
 
 ## Applicability

--- a/_rules/html-title-is-descriptive-c4a8a4.md
+++ b/_rules/html-title-is-descriptive-c4a8a4.md
@@ -15,10 +15,6 @@ input_aspects:
 authors:
   - Anne Thyme Nørregaard
   - Corbb O'Connor
-htmlHintIgnore:
-  # https://www.npmjs.com/package/htmlhint
-  # (used with `npm test` to ensure validity of code snippets)
-  - 'title-require'
 ---
 
 ## Applicability

--- a/_rules/meta-refresh-bc659a.md
+++ b/_rules/meta-refresh-bc659a.md
@@ -25,10 +25,6 @@ input_aspects:
 authors:
   - Anne Thyme Nørregaard
   - Wilco Fiers
-htmlHintIgnore:
-  # https://www.npmjs.com/package/htmlhint
-  # (used with `npm test` to ensure validity of code snippets)
-  - 'title-require'
 ---
 
 ## Applicability


### PR DESCRIPTION
There are too many rules where this linting check is disabled. We may as well set this to disabled by default.

Also, see - https://github.com/act-rules/act-rules.github.io/pull/408#discussion_r323165317

Closes issue(s): 
- NA

----

## Pull Request Etiquette

### **When creating PR:**
- Make sure you requesting to **pull a branch** (right side) to the `develop` branch (left side).

### **After creating PR:**
- Add yourself (and co-authors) as "Assignees" for PR.
- Add label to indicate if it's a `Rule`, `Definition` or `Chore`.
- Close the issue that the PR resolves (and make sure the issue is referenced in the top of this comment)
- Optionally request feedback from anyone in particular by assigning them as "Reviewers".

## How to Review And Approve
- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines. 
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.