### PR TITLE
chore: add final call duration to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,35 @@
 << Describe the changes >>
 
-Closes issue(s): 
+Closes issue(s):
+
 - (ADD ISSUE NUMBER HERE)
 
-----
+Need for Final Call
+<< choose one of the following and remove the rest >>
+<< check https://act-rules.github.io/pages/design/process/#final-call-aka-call-for-consensus-cfc >>
+This can be merged with 1 approval << choose reason: editorial changes to website/test code, adding new contributor, other (explain). >>
+This will not require a Final Call << choose reason(s): editorial changes, changes to assumptions, background, accessibility support, change to website/test code (not rule), other (explain). >>
+This will require a 1 week Final Call << small changes affecting a small number of test cases, if in doubt do not use this. >>
+This will require a 2 weeks Final Call << new rule, or substantial changes affecting a large number of test cases, if in doubt, use this. >>
+
+---
 
 ## Pull Request Etiquette
 
 ### **When creating PR:**
+
 - Make sure you requesting to **pull a branch** (right side) to the `develop` branch (left side).
 
 ### **After creating PR:**
+
 - Add yourself (and co-authors) as "Assignees" for PR.
 - Add label to indicate if it's a `Rule`, `Definition` or `Chore`.
 - Close the issue that the PR resolves (and make sure the issue is referenced in the top of this comment)
 - Optionally request feedback from anyone in particular by assigning them as "Reviewers".
 
 ## How to Review And Approve
+
 - Go to the “Files changed” tab
-- Here you will have the option to leave comments on different lines. 
+- Here you will have the option to leave comments on different lines.
 - Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
+- Make sure to also review the proposed Final Call period. In case of disagreement, the longer period wins.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ Closes issue(s):
 
 - (ADD ISSUE NUMBER HERE)
 
-Need for Final Call
+Need for Final Call:
 << choose one of the following and remove the rest >>
 << check https://act-rules.github.io/pages/design/process/#final-call-aka-call-for-consensus-cfc >>
 This can be merged with 1 approval << choose reason: editorial changes to website/test code, adding new contributor, other (explain). >>


### PR DESCRIPTION
Add a field for Final Call period to the PR template, as discussed during ACT-R call on 12/09/2019.

Closes issue(s): 
- #844 

Need for Final Call:
This will not require a Final Call (editorial change, change to process (not rule)).

----

## Pull Request Etiquette

### **When creating PR:**
- Make sure you requesting to **pull a branch** (right side) to the `develop` branch (left side).

### **After creating PR:**
- Add yourself (and co-authors) as "Assignees" for PR.
- Add label to indicate if it's a `Rule`, `Definition` or `Chore`.
- Close the issue that the PR resolves (and make sure the issue is referenced in the top of this comment)
- Optionally request feedback from anyone in particular by assigning them as "Reviewers".

## How to Review And Approve
- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines. 
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.