### PR TITLE
test: check if WCAG accessibility requirements are correct

### DIFF
--- a/_rules/__tests__/frontmatter.js
+++ b/_rules/__tests__/frontmatter.js
@@ -1,5 +1,7 @@
 const describeRule = require('../../test-utils/describe-rule')
+const scUrls = require('./../../_data/sc-urls.json')
 const { contributors } = require('./../../package.json')
+
 const contributorsNames = contributors.map(contributor => contributor.name.toLowerCase())
 
 describeRule('frontmatter', (ruleData, metaData) => {
@@ -48,11 +50,35 @@ describeRule('frontmatter', (ruleData, metaData) => {
 	 * Check if `accessibility_requirements` (if any) has expected values
 	 */
 	if (accessibility_requirements) {
+		/**
+		 * The below check the `values` for every `key - value` pair of accessibility requirements
+		 */
 		const accRequirementValues = Object.values(accessibility_requirements)
 		test.each(accRequirementValues)('has expected keys for accessibility requirement: `%p`', accReq => {
-			const requirementKeys = Object.keys(accReq).sort()
-			expect(requirementKeys.length).toBeGreaterThanOrEqual(4)
-			expect(requirementKeys).toIncludeAllMembers(['failed', 'forConformance', 'inapplicable', 'passed'])
+			const keys = Object.keys(accReq).sort()
+			expect(keys.length).toBeGreaterThanOrEqual(4)
+			expect(keys).toIncludeAllMembers(['failed', 'forConformance', 'inapplicable', 'passed'])
 		})
+
+		/**
+		 * Check of the requirement is of type `WCAG`, then the SC number and WCAG type match
+		 * Eg:
+		 * `wcag20:2.5.3` should fail, as it should be `wcag21:253`
+		 */
+		const wcagAccRequirementKeys = Object.keys(accessibility_requirements).filter(key =>
+			key.toLowerCase().includes(`wcag`)
+		)
+
+		if (wcagAccRequirementKeys.length) {
+			test.each(wcagAccRequirementKeys)(`has correct WCAG type for Success Criterion specified`, wcagReqKey => {
+				const [wcagType, successCriterion] = wcagReqKey.split(':')
+				expect(scUrls).toContainKey(successCriterion)
+				/**
+				 * convert `2.0` to `wcag20` or `2.1` to `wcag2.1`
+				 */
+				const computedWcagType = `wcag` + scUrls[successCriterion]['wcagType'].split('.').join('')
+				expect(computedWcagType).toBe(wcagType)
+			})
+		}
 	}
 })

--- a/_rules/label-content-name-mismatch-2ee8b8.md
+++ b/_rules/label-content-name-mismatch-2ee8b8.md
@@ -5,7 +5,7 @@ rule_type: atomic
 description: |
   This rule checks that interactive elements labeled through their content have their visible label as part of their accessible name.
 accessibility_requirements:
-  wcag20:2.5.3: # Label in Name
+  wcag21:2.5.3: # Label in Name
     forConformance: true
     failed: not satisfied
     passed: further testing needed


### PR DESCRIPTION
Check of the accessibility requirement specified in the frontmatter when if type WCAG has the right wcagType specified for the success criterion fulfilled.

Eg: `wcag20:2.5.3` should fail, as it should be `wcag21:253`

Closes issue(s):
- NA
