### PR TITLE
Use empty accessible name

### DIFF
--- a/_rules/form-control-accessible-name-e086e5.md
+++ b/_rules/form-control-accessible-name-e086e5.md
@@ -30,7 +30,7 @@ This rule applies to any element that is [included in the accessibility tree](#i
 
 ## Expectation
 
-Each target element has an [accessible name][] that is not only [whitespace][].
+Each target element has an [accessible name][] that is not empty (`""`).
 
 ## Assumptions
 
@@ -165,7 +165,7 @@ The explicit label is not supported on `div` elements.
 
 #### Failed Example 7
 
-The [accessible name][] is only [whitespace][].
+The [accessible name][] is empty.
 
 ```html
 <label> <input /></label>

--- a/_rules/iframe-accessible-name-cae760.md
+++ b/_rules/iframe-accessible-name-cae760.md
@@ -25,7 +25,7 @@ The rule applies to `iframe` elements that are [included in the accessibility tr
 
 ## Expectation
 
-Each target element has an [accessible name][] that is not only [whitespace][].
+Each target element has an [accessible name][] that is not empty (`""`).
 
 ## Assumptions
 
@@ -73,7 +73,7 @@ Usage of `aria-labelledby` attribute to describe the `iframe` content.
 
 #### Passed Example 4
 
-[Accessible name][] is not only [whitespace][].
+[Accessible name][] is not empty.
 
 ```html
 <iframe title=":-)" src="/test-assets/SC4-1-2-frame-doc.html"> </iframe>
@@ -131,7 +131,7 @@ Usage of `alt` attribute to describe content is not valid.
 
 #### Failed Example 7
 
-[Accessible name][] is only [whitespace][].
+[Accessible name][] is empty.
 
 ```html
 <iframe title=" " src="/test-assets/SC4-1-2-frame-doc.html"> </iframe>

--- a/_rules/image-accessible-name-23a2a8.md
+++ b/_rules/image-accessible-name-23a2a8.md
@@ -149,7 +149,7 @@ The `img` element inside a `div` positioned off screen has an empty [accessible 
 
 #### Failed Example 4
 
-The HTML `img` element has an emtpy [accessible name][].
+The HTML `img` element has an empty [accessible name][].
 
 ```html
 <img alt=" " />

--- a/_rules/image-accessible-name-23a2a8.md
+++ b/_rules/image-accessible-name-23a2a8.md
@@ -28,9 +28,9 @@ The rule applies to HTML `img` elements or any HTML element with the [semantic r
 
 ## Expectation
 
-Each target element has an [accessible name][] that is not only [whitespace][], or is marked as [decorative][].
+Each target element has an [accessible name][] that is not empty (`""`), or is marked as [decorative][].
 
-**NOTE**: An `img` element can be marked as [decorative][], by using either `role="presentation"`, `role="none"` or an empty alt attribute, `alt=""`.
+**NOTE**: An `img` element can be marked as [decorative][], by using either `role="presentation"`, `role="none"` or an empty `alt` attribute, (`alt=""` or `alt` with no value).
 
 ## Assumptions
 
@@ -115,7 +115,7 @@ The HTML `img` element is marked as [decorative][] through `role="none"`.
 
 #### Passed Example 8
 
-The HTML `img` element has an [accessible name][] that does not only consist of [whitespace][].
+The HTML `img` element has an [accessible name][] that is not empty.
 
 ```html
 <img alt=":-)" />
@@ -125,7 +125,7 @@ The HTML `img` element has an [accessible name][] that does not only consist of 
 
 #### Failed Example 1
 
-The HTML `img` element is not marked as [decorative][] and does not have an [accessible name][].
+The HTML `img` element is not marked as [decorative][] and has an empty [accessible name][].
 
 ```html
 <img />
@@ -133,7 +133,7 @@ The HTML `img` element is not marked as [decorative][] and does not have an [acc
 
 #### Failed Example 2
 
-The element with role of `img` does not have an [accessible name][].
+The element with role of `img` has an empty [accessible name][].
 
 ```html
 <div role="img"></div>
@@ -141,7 +141,7 @@ The element with role of `img` does not have an [accessible name][].
 
 #### Failed Example 3
 
-The `img` element inside a `div` positioned off screen has no [accessible name][] and is not marked as [decorative][].
+The `img` element inside a `div` positioned off screen has an empty [accessible name][] and is not marked as [decorative][].
 
 ```html
 <div style="margin-left:-9999px;"><img /></div>
@@ -149,10 +149,10 @@ The `img` element inside a `div` positioned off screen has no [accessible name][
 
 #### Failed Example 4
 
-The HTML `img` element has an [accessible name][] that only consist of [whitespace][].
+The HTML `img` element has an emtpy [accessible name][].
 
 ```html
-<img aria-label=" " />
+<img alt=" " />
 ```
 
 ### Inapplicable

--- a/_rules/image-button-accessible-name-59796f.md
+++ b/_rules/image-button-accessible-name-59796f.md
@@ -34,7 +34,7 @@ The rule applies to any HTML `input` element with a `type` attribute in the `Ima
 
 ## Expectation
 
-Each target element has an [accessible name][] that is not only [whitespace][].
+Each target element has an [accessible name][] that is not empty (`""`).
 
 ## Assumptions
 
@@ -87,7 +87,7 @@ Image button element with [accessible name][] through `aria-labelledby`
 
 #### Passed Example 5
 
-[accessible name][] is not only [whitespace][].
+[accessible name][] is not empty.
 
 ```html
 <input type="image" name="submit" src="button.gif" alt=":-)" />
@@ -105,7 +105,7 @@ Image button element with [accessible name][] through `alt` attribute
 
 #### Failed Example 1
 
-Image button element with no attributes to give [accessible name][]
+Image button element with empty [accessible name][].
 
 ```html
 <input type="image" name="submit" src="button.gif" />
@@ -113,7 +113,7 @@ Image button element with no attributes to give [accessible name][]
 
 #### Failed Example 2
 
-Image button element with empty `alt` attribute
+Image button element with empty [accessible name][].
 
 ```html
 <input type="image" name="submit" src="button.gif" alt="" />
@@ -121,7 +121,7 @@ Image button element with empty `alt` attribute
 
 #### Failed Example 3
 
-Image button with aria-labelledby that does not reference an id that exists in the same document
+Image button with empty [accessible name][] because the `aria-labelledby` attribute does not reference an id that exists in the same document.
 
 ```html
 <input type="image" name="submit" src="button.gif" aria-labelledby="id1" />
@@ -129,7 +129,7 @@ Image button with aria-labelledby that does not reference an id that exists in t
 
 #### Failed Example 4
 
-[accessible name][] is only [whitespace][].
+[accessible name][] is empty.
 
 ```html
 <input type="image" name="submit" src="button.gif" alt=" " />

--- a/_rules/link-accessible-name-c487ae.md
+++ b/_rules/link-accessible-name-c487ae.md
@@ -38,7 +38,7 @@ The rule applies to any HTML element with the [semantic role](#semantic-role) of
 
 ## Expectation
 
-Each target element has an [accessible name][] that is not only [whitespace][].
+Each target element has an [accessible name][] that is not empty (`""`).
 
 ## Assumptions
 
@@ -157,7 +157,7 @@ When `link` is off screen.
 
 #### Passed Example 11
 
-`a` element where [accessible name][] does not only consist of [whitespace][].
+`a` element where [accessible name][] is not empty.
 
 ```html
 <a href="http://www.w3.org/WAI">:-)</a>
@@ -167,7 +167,7 @@ When `link` is off screen.
 
 #### Failed Example 1
 
-Image link without [accessible name][].
+Image link with empty [accessible name][].
 
 ```html
 <a href="http://www.w3.org/WAI"><img src="#"/></a>
@@ -226,7 +226,7 @@ Link with image that has empty `aria-labelledby`.
 
 #### Failed Example 8
 
-Link is completely empty, but still shows up in focus order, so it should have an [accessible name][].
+Link is completely empty, but still shows up in focus order, so it should have an non-empty [accessible name][].
 
 ```html
 <a href="http://www.w3.org/WAI"></a>
@@ -234,7 +234,7 @@ Link is completely empty, but still shows up in focus order, so it should have a
 
 #### Failed Example 9
 
-`area` element with `href` attribute does not have [accessible name][].
+`area` element with `href` attribute has an empty [accessible name][].
 
 ```html
 <img src="planets.gif" width="145" height="126" alt="Planets" usemap="#planetmap" />
@@ -246,7 +246,7 @@ Link is completely empty, but still shows up in focus order, so it should have a
 
 #### Failed Example 10
 
-`a` element where [accessible name][] through content only consist of [whitespace][].
+`a` element where [accessible name][] through content is empty.
 
 ```html
 <a href="http://www.w3.org/WAI"> </a>

--- a/pages/glossary/accessible-name.md
+++ b/pages/glossary/accessible-name.md
@@ -8,3 +8,13 @@ The programmatically determined name of a user interface element that is [includ
 The accessible name is calculated using the [accessible name and description computation](https://www.w3.org/TR/accname).
 
 For native markup languages, such as HTML and SVG, additional information on how to calculate the accessible name can be found in [HTML Accessibility API Mappings 1.0, Accessible Name and Description Computation (working draft)](https://www.w3.org/TR/html-aam/#accessible-name-and-description-computation) and [SVG Accessibility API Mappings, Name and Description (working draft)](https://www.w3.org/TR/svg-aam/#mapping_additional).
+
+**Note**: As per the [accessible name and description computation](https://www.w3.org/TR/accname), each element always has an accessible name. When no accessible name is provided, the element will nonetheless be assigned an empty (`""`) one.
+
+**Note**: As per the [accessible name and description computation](https://www.w3.org/TR/accname), accessible names are [flat string](https://www.w3.org/TR/accname-1.1/#terminology) trimmed of leading and trailing whitespace. Notably, it is not possible for a non-empty accessible name to be composed only of whitespace since these must be trimmed.
+
+#### Accessibility Support
+
+- Because the [accessible name and description computation](https://www.w3.org/TR/accname) is not clear about which whitespace are considered, browsers behave differently when trimming and flattening the accessible name. For example, some browsers completely trim non-breaking spaces while some keep them in the accessible name.
+- There exists a popular browser which does not perform the same trimming and flattening depending whether the accessible name comes from content, an `aria-label` attribute, or an `alt` attribute.
+- There exists a popular browser which assign no accessible name (`null`) when none is provided, instead of assigned an empty accessible name (`""`).


### PR DESCRIPTION
* Add notes and accessibility support on definition of accessible name to mention trimming and flattening and incoherent browsers behaviour.
* Replace "has an accessible name that is not only whitespace" by "that is not empty (`""`)" where relevant.

Closes issue(s): #976 (mostly)

Need for Final Call:
This will require a 1 week Final Call (small change that should not have any implication on test cases).

---

## Pull Request Etiquette

### **When creating PR:**

- Make sure you requesting to **pull a branch** (right side) to the `develop` branch (left side).

### **After creating PR:**

- Add yourself (and co-authors) as "Assignees" for PR.
- Add label to indicate if it's a `Rule`, `Definition` or `Chore`.
- Close the issue that the PR resolves (and make sure the issue is referenced in the top of this comment)
- Optionally request feedback from anyone in particular by assigning them as "Reviewers".

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Final Call period. In case of disagreement, the longer period wins.
