### PR TITLE
fix: update repo url to `https` instead of `git`

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,6 @@
 	},
 	"homepage": "https://github.com/act-rules/act-rules.github.io",
 	"repository": {
-		"type": "git",
 		"url": "https://github.com/act-rules/act-rules.github.io"
 	},
 	"bugs": {


### PR DESCRIPTION
This PR updates the repository url to use `https` as against `git`.
The repo url is used by the ACT Rules website to resolve some URL's dynamically when the site is built & these need to be https.

Closes issue(s):
- https://github.com/act-rules/act-rules-web/issues/44

