### PR TITLE
feat: allow `acknowledgements` & `previous_authors` in rule frontmatter.

### DIFF
--- a/_rules/__tests__/frontmatter.js
+++ b/_rules/__tests__/frontmatter.js
@@ -1,17 +1,16 @@
 const describeRule = require('../../test-utils/describe-rule')
-// const scUrls = require('./../../_data/sc-urls.json')
 const { contributors } = require('./../../package.json')
 
 const contributorsNames = contributors.map(contributor => contributor.name.toLowerCase())
 
 describeRule('frontmatter', (ruleData, metaData) => {
 	const { frontmatter } = ruleData
-	const { rule_type, authors, accessibility_requirements } = frontmatter
+	const { rule_type, acknowledgements, accessibility_requirements } = frontmatter
 
 	/**
 	 * Check for `required` properties
 	 */
-	const requiredProps = ['id', 'name', 'rule_type', 'description', 'accessibility_requirements', 'authors']
+	const requiredProps = ['id', 'name', 'rule_type', 'description', 'accessibility_requirements', 'acknowledgements']
 	test.each(requiredProps)('has required property `%s`', requiredProp => {
 		expect(frontmatter).toHaveProperty(requiredProp)
 	})
@@ -42,7 +41,10 @@ describeRule('frontmatter', (ruleData, metaData) => {
 	/**
 	 * Check if listed `authors` have meta data as contributors in package.json
 	 */
-	test.each(authors)('has contributor data for author: `%s`', author => {
+
+	const { authors, previous_authors = [] } = acknowledgements
+	const allAuthors = [...authors, ...previous_authors]
+	test.each(allAuthors)('has contributor data for author: `%s`', author => {
 		expect(contributorsNames).toContain(author.toLowerCase())
 	})
 

--- a/_rules/aria-attr-defined-5f99a7.md
+++ b/_rules/aria-attr-defined-5f99a7.md
@@ -7,8 +7,9 @@ description: |
 accessibility_requirements:
 input_aspects:
   - DOM Tree
-authors:
-  - Jey Nandakumar
+acknowledgements:
+  authors:
+    - Jey Nandakumar
 ---
 
 ## Applicability

--- a/_rules/aria-hidden-no-focusable-content-6cfa84.md
+++ b/_rules/aria-hidden-no-focusable-content-6cfa84.md
@@ -18,8 +18,9 @@ accessibility_requirements:
 input_aspects:
   - DOM Tree
   - CSS Styling
-authors:
-  - Wilco Fiers
+acknowledgements:
+  authors:
+    - Wilco Fiers
 ---
 
 ## Applicability

--- a/_rules/aria-state-or-property-permitted-5c01ea.md
+++ b/_rules/aria-state-or-property-permitted-5c01ea.md
@@ -13,8 +13,9 @@ accessibility_requirements:
     inapplicable: satisfied
 input_aspects:
   - DOM Tree
-authors:
-  - Anne Thyme Nørregaard
+acknowledgements:
+  authors:
+    - Anne Thyme Nørregaard
 ---
 
 ## Applicability

--- a/_rules/aria-state-or-property-valid-value-6a7281.md
+++ b/_rules/aria-state-or-property-valid-value-6a7281.md
@@ -14,9 +14,10 @@ accessibility_requirements:
 input_aspects:
   - DOM Tree
   - CSS Styling
-authors:
-  - Wilco Fiers
-  - Anne Thyme Nørregaard
+acknowledgements:
+  authors:
+    - Wilco Fiers
+    - Anne Thyme Nørregaard
 ---
 
 ## Applicability

--- a/_rules/attr-not-duplicated-e6952f.md
+++ b/_rules/attr-not-duplicated-e6952f.md
@@ -12,9 +12,10 @@ accessibility_requirements:
     inapplicable: further testing needed
 input_aspects:
   - Source code
-authors:
-  - Wilco Fiers
-  - Emma Pratt Richens
+acknowledgements:
+  authors:
+    - Wilco Fiers
+    - Emma Pratt Richens
 htmlHintIgnore:
   # https://www.npmjs.com/package/htmlhint
   # (used with `npm test` to ensure validity of code snippets)

--- a/_rules/audio-as-media-alternative-afb423.md
+++ b/_rules/audio-as-media-alternative-afb423.md
@@ -9,9 +9,10 @@ input_aspects:
   - DOM Tree
   - CSS Styling
   - Audio output
-authors:
-  - Wilco Fiers
-  - Brian Bors
+acknowledgements:
+  authors:
+    - Wilco Fiers
+    - Brian Bors
 ---
 
 ## Applicability

--- a/_rules/audio-text-alternative-e7aa44.md
+++ b/_rules/audio-text-alternative-e7aa44.md
@@ -13,11 +13,12 @@ accessibility_requirements:
 input_rules:
   - 2eb176
   - afb423
-authors:
-  - Wilco Fiers
-  - Brian Bors
-  - John Hicks
-  - Rafal Charlampowicz
+acknowledgements:
+  authors:
+    - Wilco Fiers
+    - Brian Bors
+    - John Hicks
+    - Rafal Charlampowicz
 ---
 
 ## Applicability

--- a/_rules/audio-transcript-2eb176.md
+++ b/_rules/audio-transcript-2eb176.md
@@ -5,14 +5,14 @@ rule_type: atomic
 description: |
   Non-streaming `audio` elements must have a text alternative for all included auditory information.
 accessibility_requirements:
-
 input_aspects:
   - DOM Tree
   - CSS Styling
   - Audio output
-authors:
-  - Wilco Fiers
-  - Brian Bors
+acknowledgements:
+  authors:
+    - Wilco Fiers
+    - Brian Bors
 ---
 
 ## Applicability

--- a/_rules/auto-play-audio-does-not-exceed-3-seconds-aaa1bf.md
+++ b/_rules/auto-play-audio-does-not-exceed-3-seconds-aaa1bf.md
@@ -10,9 +10,10 @@ input_aspects:
   - CSS Styling
   - Audio output
   - Visual output
-authors:
-  - Anne Thyme Nørregaard
-  - Bryn Anderson
+acknowledgements:
+  authors:
+    - Anne Thyme Nørregaard
+    - Bryn Anderson
 ---
 
 ## Applicability

--- a/_rules/auto-play-audio-has-control-mechanism-4c31df.md
+++ b/_rules/auto-play-audio-has-control-mechanism-4c31df.md
@@ -10,9 +10,10 @@ input_aspects:
   - CSS Styling
   - Audio output
   - Visual output
-authors:
-  - Anne Thyme Nørregaard
-  - Bryn Anderson
+acknowledgements:
+  authors:
+    - Anne Thyme Nørregaard
+    - Bryn Anderson
 htmlHintIgnore:
   # https://www.npmjs.com/package/htmlhint
   # (used with `npm test` to ensure validity of code snippets)

--- a/_rules/autocomplete-valid-value-73f2c2.md
+++ b/_rules/autocomplete-valid-value-73f2c2.md
@@ -13,8 +13,9 @@ accessibility_requirements:
 input_aspects:
   - DOM Tree
   - CSS Styling
-authors:
-  - Wilco Fiers
+acknowledgements:
+  authors:
+    - Wilco Fiers
 ---
 
 ## Applicability

--- a/_rules/button-accessible-name-97a4e1.md
+++ b/_rules/button-accessible-name-97a4e1.md
@@ -13,9 +13,10 @@ accessibility_requirements:
 input_aspects:
   - DOM Tree
   - CSS Styling
-authors:
-  - Wilco Fiers
-  - Stein Erik Skotkjerra
+acknowledgements:
+  authors:
+    - Wilco Fiers
+    - Stein Erik Skotkjerra
 ---
 
 ## Applicability

--- a/_rules/css-restrict-orientation-b33eff.md
+++ b/_rules/css-restrict-orientation-b33eff.md
@@ -12,10 +12,11 @@ accessibility_requirements:
     inapplicable: further testing needed
 input_aspects:
   - DOM Tree
-  - CSS Styling
-authors:
-  - Jey Nandakumar
-  - Audrey Maniez
+    - CSS Styling
+acknowledgements:
+  authors:
+    - Jey Nandakumar
+    - Audrey Maniez
 ---
 
 ## Applicability

--- a/_rules/element-lang-valid-de46e4.md
+++ b/_rules/element-lang-valid-de46e4.md
@@ -12,9 +12,10 @@ accessibility_requirements:
     inapplicable: further testing needed
 input_aspects:
   - DOM Tree
-authors:
-  - Bryn Anderson
-  - Jey Nandakumar
+acknowledgements:
+  authors:
+    - Bryn Anderson
+    - Jey Nandakumar
 ---
 
 ## Applicability

--- a/_rules/focusable-no-keyboard-trap-80af7b.md
+++ b/_rules/focusable-no-keyboard-trap-80af7b.md
@@ -13,10 +13,11 @@ accessibility_requirements:
 input_rules:
   - a1b64e
   - ebe86a
-authors:
-  - Geir Sindre Fossøy
-  - Dagfinn Rømen
-  - Anne Thyme Nørregaard
+acknowledgements:
+  authors:
+    - Geir Sindre Fossøy
+    - Dagfinn Rømen
+    - Anne Thyme Nørregaard
 ---
 
 ## Applicability

--- a/_rules/focusable-no-keyboard-trap-non-standard-nav-ebe86a.md
+++ b/_rules/focusable-no-keyboard-trap-non-standard-nav-ebe86a.md
@@ -8,14 +8,15 @@ accessibility_requirements:
 input_aspects:
   - DOM Tree
   - CSS Styling
-authors:
-  - Dagfinn Rømen
-  - Geir Sindre Fossøy
-  - Malin Øvrebø
-  - Shadi Abou-Zahra
-  - Carlos Duarte
-  - Anne Thyme Nørregaard
-  - Stein Erik Skotkjerra
+acknowledgements:
+  authors:
+    - Dagfinn Rømen
+    - Geir Sindre Fossøy
+    - Malin Øvrebø
+    - Shadi Abou-Zahra
+    - Carlos Duarte
+    - Anne Thyme Nørregaard
+    - Stein Erik Skotkjerra
 ---
 
 ## Applicability

--- a/_rules/focusable-no-keyboard-trap-standard-nav-a1b64e.md
+++ b/_rules/focusable-no-keyboard-trap-standard-nav-a1b64e.md
@@ -8,14 +8,15 @@ accessibility_requirements:
 input_aspects:
   - DOM Tree
   - CSS Styling
-authors:
-  - Dagfinn Rømen
-  - Geir Sindre Fossøy
-  - Malin Øvrebø
-  - Shadi Abou-Zahra
-  - Carlos Duarte
-  - Anne Thyme Nørregaard
-  - Stein Erik Skotkjerra
+acknowledgements:
+  authors:
+    - Dagfinn Rømen
+    - Geir Sindre Fossøy
+    - Malin Øvrebø
+    - Shadi Abou-Zahra
+    - Carlos Duarte
+    - Anne Thyme Nørregaard
+    - Stein Erik Skotkjerra
 ---
 
 ## Applicability

--- a/_rules/form-control-accessible-name-e086e5.md
+++ b/_rules/form-control-accessible-name-e086e5.md
@@ -12,9 +12,10 @@ accessibility_requirements:
     inapplicable: further testing needed
 input_aspects:
   - DOM Tree
-authors:
-  - Anne Thyme Nørregaard
-  - Bryn Anderson
+acknowledgements:
+  authors:
+    - Anne Thyme Nørregaard
+    - Bryn Anderson
 ---
 
 ## Applicability

--- a/_rules/form-control-label-descriptive-cc0f0a.md
+++ b/_rules/form-control-label-descriptive-cc0f0a.md
@@ -13,9 +13,10 @@ accessibility_requirements:
 input_aspects:
   - DOM Tree
   - CSS Styling
-authors:
-  - Dagfinn Rømen
-  - Geir Sindre Fossøy
+acknowledgements:
+  authors:
+    - Dagfinn Rømen
+    - Geir Sindre Fossøy
 ---
 
 ## Applicability

--- a/_rules/heading-descriptive-b49b2e.md
+++ b/_rules/heading-descriptive-b49b2e.md
@@ -13,10 +13,11 @@ accessibility_requirements:
 input_aspects:
   - DOM Tree
   - CSS Styling
-authors:
-  - Dagfinn Rømen
-  - Geir Sindre Fossøy
-  - Carlos Duarte
+acknowledgements:
+  authors:
+    - Dagfinn Rømen
+    - Geir Sindre Fossøy
+    - Carlos Duarte
 ---
 
 ## Applicability

--- a/_rules/html-page-lang-b5c3f8.md
+++ b/_rules/html-page-lang-b5c3f8.md
@@ -12,9 +12,10 @@ accessibility_requirements:
     inapplicable: further testing needed
 input_aspects:
   - DOM Tree
-authors:
-  - Annika Nietzio
-  - Jey Nandakumar
+acknowledgements:
+  authors:
+    - Annika Nietzio
+    - Jey Nandakumar
 ---
 
 ## Applicability

--- a/_rules/html-page-lang-valid-bf051a.md
+++ b/_rules/html-page-lang-valid-bf051a.md
@@ -12,9 +12,10 @@ accessibility_requirements:
     inapplicable: further testing needed
 input_aspects:
   - DOM Tree
-authors:
-  - Annika Nietzio
-  - Jey Nandakumar
+acknowledgements:
+  authors:
+    - Annika Nietzio
+    - Jey Nandakumar
 ---
 
 ## Applicability

--- a/_rules/html-page-lang-xml-lang-match-5b7ae0.md
+++ b/_rules/html-page-lang-xml-lang-match-5b7ae0.md
@@ -12,9 +12,11 @@ accessibility_requirements:
     inapplicable: further testing needed
 input_aspects:
   - DOM Tree # The tree that HTML is parsed into.
-authors:
-  - Annika Nietzio
-  - Jey Nandakumar
+acknowledgements:
+  authors:
+    - Jey Nandakumar
+  previous_authors:
+    - Annika Nietzio
 ---
 
 ## Applicability

--- a/_rules/html-page-title-2779a5.md
+++ b/_rules/html-page-title-2779a5.md
@@ -12,12 +12,13 @@ accessibility_requirements:
     inapplicable: further testing needed
 input_aspects:
   - DOM Tree
-authors:
-  - Wilco Fiers
-  - Stein Erik Skotkjerra
-  - Bryn Anderson
-  - Anne Thyme Nørregaard
-  - Jey Nandakumar
+acknowledgements:
+  authors:
+    - Wilco Fiers
+    - Stein Erik Skotkjerra
+    - Bryn Anderson
+    - Anne Thyme Nørregaard
+    - Jey Nandakumar
 htmlHintIgnore:
   # https://www.npmjs.com/package/htmlhint
   # (used with `npm test` to ensure validity of code snippets)

--- a/_rules/html-page-title-descriptive-c4a8a4.md
+++ b/_rules/html-page-title-descriptive-c4a8a4.md
@@ -12,9 +12,10 @@ accessibility_requirements:
     inapplicable: further testing needed
 input_aspects:
   - DOM Tree
-authors:
-  - Anne Thyme Nørregaard
-  - Corbb O'Connor
+acknowledgements:
+  authors:
+    - Anne Thyme Nørregaard
+    - Corbb O'Connor
 htmlHintIgnore:
   # https://www.npmjs.com/package/htmlhint
   # (used with `npm test` to ensure validity of code snippets)

--- a/_rules/id-value-unique-3ea0c8.md
+++ b/_rules/id-value-unique-3ea0c8.md
@@ -12,9 +12,10 @@ accessibility_requirements:
     inapplicable: further testing needed
 input_aspects:
   - DOM Tree
-authors:
-  - Bryn Anderson
-  - Anne Thyme Nørregaard
+acknowledgements:
+  authors:
+    - Bryn Anderson
+    - Anne Thyme Nørregaard
 htmlHintIgnore:
   # https://www.npmjs.com/package/htmlhint
   # (used with `npm test` to ensure validity of code snippets)

--- a/_rules/iframe-accessible-name-cae760.md
+++ b/_rules/iframe-accessible-name-cae760.md
@@ -13,8 +13,9 @@ accessibility_requirements:
 input_aspects:
   - DOM Tree
   - CSS Styling
-authors:
-  - Jey Nandakumar
+acknowledgements:
+  authors:
+    - Jey Nandakumar
 ---
 
 ## Applicability

--- a/_rules/iframe-identical-name-equivalent-purpose-4b1c6c.md
+++ b/_rules/iframe-identical-name-equivalent-purpose-4b1c6c.md
@@ -13,9 +13,10 @@ accessibility_requirements:
 input_aspects:
   - DOM Tree
   - CSS Styling
-authors:
-  - Jey Nandakumar
-  - Audrey Maniez
+acknowledgements:
+  authors:
+    - Jey Nandakumar
+    - Audrey Maniez
 ---
 
 ## Applicability

--- a/_rules/image-accessible-name-23a2a8.md
+++ b/_rules/image-accessible-name-23a2a8.md
@@ -13,9 +13,10 @@ accessibility_requirements:
 input_aspects:
   - DOM Tree
   - CSS Styling
-authors:
-  - Anne Thyme Nørregaard
-  - Stein Erik Skotkjerra
+acknowledgements:
+  authors:
+    - Anne Thyme Nørregaard
+    - Stein Erik Skotkjerra
 htmlHintIgnore:
   # https://www.npmjs.com/package/htmlhint
   # (used with `npm test` to ensure validity of code snippets)

--- a/_rules/image-button-accessible-name-59796f.md
+++ b/_rules/image-button-accessible-name-59796f.md
@@ -18,8 +18,9 @@ accessibility_requirements:
 input_aspects: # Remove what is not applicable
   - DOM Tree
   - CSS Styling
-authors:
-  - Anne Thyme Nørregaard
+acknowledgements:
+  authors:
+    - Anne Thyme Nørregaard
 htmlHintIgnore:
   # https://www.npmjs.com/package/htmlhint
   # (used with `npm test` to ensure validity of code snippets)

--- a/_rules/image-filename-as-accessible-name-9eb3f6.md
+++ b/_rules/image-filename-as-accessible-name-9eb3f6.md
@@ -13,8 +13,9 @@ accessibility_requirements:
 input_aspects:
   - DOM Tree
   - CSS Styling
-authors:
-  - Bryn Anderson
+acknowledgements:
+  authors:
+    - Bryn Anderson
 ---
 
 ## Applicability

--- a/_rules/link-accessible-name-c487ae.md
+++ b/_rules/link-accessible-name-c487ae.md
@@ -23,9 +23,10 @@ accessibility_requirements:
 input_aspects:
   - DOM Tree
   - CSS Styling
-authors:
-  - Wilco Fiers
-  - Anne Thyme Nørregaard
+acknowledgements:
+  authors:
+    - Wilco Fiers
+    - Anne Thyme Nørregaard
 htmlHintIgnore:
   # https://www.npmjs.com/package/htmlhint
   # (used with `npm test` to ensure validity of code snippets)

--- a/_rules/links-identical-name-equivalent-purpose-b20e66.md
+++ b/_rules/links-identical-name-equivalent-purpose-b20e66.md
@@ -13,8 +13,9 @@ accessibility_requirements:
 input_aspects:
   - DOM Tree
   - CSS Styling
-authors:
-  - Anne Thyme Nørregaard
+acknowledgements:
+  authors:
+    - Anne Thyme Nørregaard
 htmlHintIgnore:
   # https://www.npmjs.com/package/htmlhint
   # (used with `npm test` to ensure validity of code snippets)

--- a/_rules/meta-refresh-no-delay-bc659a.md
+++ b/_rules/meta-refresh-no-delay-bc659a.md
@@ -22,9 +22,10 @@ accessibility_requirements:
     inapplicable: further testing needed
 input_aspects:
   - DOM Tree
-authors:
-  - Anne Thyme Nørregaard
-  - Wilco Fiers
+acknowledgements:
+  authors:
+    - Anne Thyme Nørregaard
+    - Wilco Fiers
 htmlHintIgnore:
   # https://www.npmjs.com/package/htmlhint
   # (used with `npm test` to ensure validity of code snippets)

--- a/_rules/meta-viewport-b4f0c3.md
+++ b/_rules/meta-viewport-b4f0c3.md
@@ -12,9 +12,10 @@ accessibility_requirements:
     inapplicable: further testing needed
 input_aspects:
   - DOM Tree
-authors:
-  - Jey Nandakumar
-  - Audrey Maniez
+acknowledgements:
+  authors:
+    - Jey Nandakumar
+    - Audrey Maniez
 ---
 
 ## Applicability

--- a/_rules/no-auto-play-audio-80f0bf.md
+++ b/_rules/no-auto-play-audio-80f0bf.md
@@ -13,9 +13,10 @@ accessibility_requirements:
 input_rules:
   - 4c31df
   - aaa1bf
-authors:
-  - Anne Thyme Nørregaard
-  - Bryn ANderson
+acknowledgements:
+  authors:
+    - Anne Thyme Nørregaard
+    - Bryn Anderson
 htmlHintIgnore:
   # https://www.npmjs.com/package/htmlhint
   # (used with `npm test` to ensure validity of code snippets)

--- a/_rules/role-attribute-valid-value-674b10.md
+++ b/_rules/role-attribute-valid-value-674b10.md
@@ -13,8 +13,9 @@ accessibility_requirements:
 input_aspects:
   - DOM Tree
   - CSS Styling
-authors:
-  - Jey Nandakumar
+acknowledgements:
+  authors:
+    - Jey Nandakumar
 ---
 
 ## Applicability

--- a/_rules/role-required-states-and-properties-4e8ab6.md
+++ b/_rules/role-required-states-and-properties-4e8ab6.md
@@ -12,8 +12,9 @@ accessibility_requirements:
     inapplicable: further testing needed
 input_aspects:
   - DOM Tree
-authors:
-  - Anne Thyme Nørregaard
+acknowledgements:
+  authors:
+    - Anne Thyme Nørregaard
 ---
 
 ## Applicability

--- a/_rules/video-alternative-for-auditory-eac66b.md
+++ b/_rules/video-alternative-for-auditory-eac66b.md
@@ -13,9 +13,10 @@ accessibility_requirements:
 input_rules:
   - ab4d13
   - f51b46
-authors:
-  - Wilco Fiers
-  - Brian Bors
+acknowledgements:
+  authors:
+    - Wilco Fiers
+    - Brian Bors
 ---
 
 ## Applicability

--- a/_rules/video-alternative-for-visual-c5a4ea.md
+++ b/_rules/video-alternative-for-visual-c5a4ea.md
@@ -15,9 +15,10 @@ input_rules:
   - 1a02b0
   - f196ce
   - ab4d13
-authors:
-  - Wilco Fiers
-  - Brian Bors
+acknowledgements:
+  authors:
+    - Wilco Fiers
+    - Brian Bors
 ---
 
 ## Test Procedure

--- a/_rules/video-as-media-alternative-ab4d13.md
+++ b/_rules/video-as-media-alternative-ab4d13.md
@@ -9,9 +9,10 @@ input_aspects:
   - DOM Tree
   - CSS Styling
   - Audio output
-authors:
-  - Wilco Fiers
-  - Brian Bors
+acknowledgements:
+  authors:
+    - Wilco Fiers
+    - Brian Bors
 ---
 
 ## Applicability

--- a/_rules/video-audio-description-1ea59c.md
+++ b/_rules/video-audio-description-1ea59c.md
@@ -10,9 +10,10 @@ input_aspects:
   - CSS Styling
   - Audio output
   - Visual output
-authors:
-  - Wilco Fiers
-  - Brian Bors
+acknowledgements:
+  authors:
+    - Wilco Fiers
+    - Brian Bors
 ---
 
 ## Applicability

--- a/_rules/video-captions-f51b46.md
+++ b/_rules/video-captions-f51b46.md
@@ -10,9 +10,10 @@ input_aspects:
   - CSS Styling
   - Audio output
   - Visual output
-authors:
-  - Wilco Fiers
-  - Brian Bors
+acknowledgements:
+  authors:
+    - Wilco Fiers
+    - Brian Bors
 ---
 
 ## Applicability

--- a/_rules/video-description-track-f196ce.md
+++ b/_rules/video-description-track-f196ce.md
@@ -10,9 +10,10 @@ input_aspects:
   - CSS Styling
   - Audio output
   - Visual output
-authors:
-  - Wilco Fiers
-  - Brian Bors
+acknowledgements:
+  authors:
+    - Wilco Fiers
+    - Brian Bors
 ---
 
 ## Applicability

--- a/_rules/video-only-alternative-for-visual-c3232f.md
+++ b/_rules/video-only-alternative-for-visual-c3232f.md
@@ -15,11 +15,12 @@ input_rules:
   - ac7dc6
   - ee13b5
   - d7ba54
-authors:
-  - Wilco Fiers
-  - Brian Bors
-  - John Hicks
-  - Rafal Charlampowicz
+acknowledgements:
+  authors:
+    - Wilco Fiers
+    - Brian Bors
+    - John Hicks
+    - Rafal Charlampowicz
 htmlHintIgnore:
   # https://www.npmjs.com/package/htmlhint
   # (used with `npm test` to ensure validity of code snippets)

--- a/_rules/video-only-as-media-alternative-fd26cf.md
+++ b/_rules/video-only-as-media-alternative-fd26cf.md
@@ -9,9 +9,10 @@ input_aspects:
   - DOM Tree
   - CSS Styling
   - Audio output
-authors:
-  - Wilco Fiers
-  - Brian Bors
+acknowledgements:
+  authors:
+    - Wilco Fiers
+    - Brian Bors
 ---
 
 ## Applicability

--- a/_rules/video-only-audio-track-d7ba54.md
+++ b/_rules/video-only-audio-track-d7ba54.md
@@ -10,8 +10,9 @@ input_aspects:
   - CSS Styling
   - Audio output
   - Visual output
-authors:
-  - Brian Bors
+acknowledgements:
+  authors:
+    - Brian Bors
 ---
 
 ## Applicability

--- a/_rules/video-only-description-track-ac7dc6.md
+++ b/_rules/video-only-description-track-ac7dc6.md
@@ -10,9 +10,10 @@ input_aspects:
   - CSS Styling
   - Audio output
   - Visual output
-authors:
-  - Wilco Fiers
-  - Brian Bors
+acknowledgements:
+  authors:
+    - Wilco Fiers
+    - Brian Bors
 ---
 
 ## Applicability

--- a/_rules/video-only-transcript-ee13b5.md
+++ b/_rules/video-only-transcript-ee13b5.md
@@ -10,9 +10,10 @@ input_aspects:
   - CSS Styling
   - Audio output
   - Visual output
-authors:
-  - Wilco Fiers
-  - Brian Bors
+acknowledgements:
+  authors:
+    - Wilco Fiers
+    - Brian Bors
 htmlHintIgnore:
   # https://www.npmjs.com/package/htmlhint
   # (used with `npm test` to ensure validity of code snippets)

--- a/_rules/video-strict-alternative-for-visual-1ec09b.md
+++ b/_rules/video-strict-alternative-for-visual-1ec09b.md
@@ -14,9 +14,10 @@ input_rules:
   - 1ea59c
   - ab4d13
   - f196ce
-authors:
-  - Wilco Fiers
-  - Brian Bors
+acknowledgements:
+  authors:
+    - Wilco Fiers
+    - Brian Bors
 ---
 
 ## Applicability

--- a/_rules/video-transcript-1a02b0.md
+++ b/_rules/video-transcript-1a02b0.md
@@ -15,9 +15,10 @@ input_aspects:
   - CSS Styling
   - Audio output
   - Visual output
-authors:
-  - Wilco Fiers
-  - Brian Bors
+acknowledgements:
+  authors:
+    - Wilco Fiers
+    - Brian Bors
 htmlHintIgnore:
   # https://www.npmjs.com/package/htmlhint
   # (used with `npm test` to ensure validity of code snippets)

--- a/_rules/visible-label-in-accessible-name-2ee8b8.md
+++ b/_rules/visible-label-in-accessible-name-2ee8b8.md
@@ -13,10 +13,11 @@ accessibility_requirements:
 input_aspects:
   - DOM Tree
   - CSS Styling
-authors:
-  - Anne Thyme Nørregaard
-  - Bryn Anderson
-  - Jey Nandakumar
+acknowledgements:
+  authors:
+    - Anne Thyme Nørregaard
+    - Bryn Anderson
+    - Jey Nandakumar
 ---
 
 ## Applicability


### PR DESCRIPTION
- Update all rules to have `acknowledgements` section, which for now has `authors` and optionally `previous_authors`.
- Updated the tests to adapt to this change.

We can additionally add `reviewers` to the acknowledgement sections too.

>Note: the website needs to change to adapt to this change, but merging this will simply not break the website, but authors will not be shown for the time being. I am working towards a PR in the website repository for the same.

>Note: Also, rules currently authored will need to follow this structure in the frontmatter.


Closes issue(s):
- https://github.com/act-rules/act-rules.github.io/issues/239
