### PR TITLE
fix: update type of `mathml` examples

### DIFF
--- a/_rules/aria-state-or-property-valid-value-6a7281.md
+++ b/_rules/aria-state-or-property-valid-value-6a7281.md
@@ -266,7 +266,7 @@ Element has ARIA role, but no ARIA states or properties
 
 `aria-hidden` state on an element that is not an HTML or SVG element
 
-```html
+```xml
 <math aria-hidden="true"></math>
 ```
 

--- a/_rules/html-page-lang-b5c3f8.md
+++ b/_rules/html-page-lang-b5c3f8.md
@@ -105,6 +105,6 @@ The rule does not apply to `svg` element.
 
 The rule does not apply to `math` element.
 
-```svg
+```xml
 <math></math>
 ```

--- a/_rules/html-page-lang-xml-lang-match-5b7ae0.md
+++ b/_rules/html-page-lang-xml-lang-match-5b7ae0.md
@@ -147,6 +147,6 @@ This rule does not apply to elements without an `xml:lang` attribute.
 
 This rule does not apply to `math` elements.
 
-```html
+```xml
 <math xml:lang="en"></math>
 ```


### PR DESCRIPTION
Change the type of `mathml` examples, so that testcases are generated with the right extension.

Closes issue(s):
- NA
