### PR TITLE
chore: use `aria-query` to improve ignore spelling words

### DIFF
--- a/__tests__/spelling-ignore.yml
+++ b/__tests__/spelling-ignore.yml
@@ -4,20 +4,8 @@
 - WAI
 - W3C
 
-# Generic HTML tag(s)
-- html
-- iframe
-- img
-- ul
-- ol
-- dl
-- li
-- dd
-- dt
-- frameset
-- h1
-- h1-h6
-- svg
+# Tag(s)
+- svg # `aria-query` dom tags does not list `svg`
 
 # Domain-specific words, Definitions & other allowed terms
 - URI
@@ -46,6 +34,7 @@
 - testrunner
 - color
 - focusable
+- Focusable
 - unfocusable
 - tabindex
 - whitespace
@@ -56,10 +45,6 @@
 - autoplay
 - autoplays
 - presentational
-
-# spell checker checks against strict casing & hence some repeated words here
-- Autocomplete
-- Focusable
 
 # Parts of url
 - wai-aria
@@ -77,39 +62,14 @@
 - level1-frame1
 - XYZ
 
-# Attributes
+# Attributes (repeated words with casing as retext-spell has no config to ignore casing)
 - href
 - src
-- aria-labelled
-- aria-labelledby
 - autofill-field
-- combobox
-- spinbutton
-- gridcell
-- menuitem
-- menuitemcheckbox
-- menuitemradio
-- searchbox
-- treeitem
-- listbox
-- listitem
-- tablist
-- tabpanel
-- doc-biblioentry
-- textbox
 - autocomplete
-- textarea
-- autoplay
+- Autocomplete
 - tristate
-- scrollbar
 - viewport
-- figcaption
-- aria-errormessage
-- aria-rowindex
-- aria-valuemin
-- aria-valuemax
-- aria-valuenow
-- aria-dropeffect
 - lang
 - xml:lang
 - http-equiv

--- a/__tests__/spelling-ignore.yml
+++ b/__tests__/spelling-ignore.yml
@@ -65,6 +65,7 @@
 # Attributes (repeated words with casing as retext-spell has no config to ignore casing)
 - href
 - src
+- aria-labelled # used to demonstrate wrong attribute
 - autofill-field
 - autocomplete
 - Autocomplete

--- a/__tests__/spelling.js
+++ b/__tests__/spelling.js
@@ -11,24 +11,13 @@ const yaml = require('js-yaml')
 const fs = require('fs')
 const gfmCodeBlocks = require('gfm-code-blocks')
 const reporter = require('vfile-reporter')
+const ariaQuery = require('aria-query')
 
 const describeRule = require('../test-utils/describe-rule')
 
-const ignoreWords = yaml.safeLoad(fs.readFileSync('./__tests__/spelling-ignore.yml', 'utf8'))
-// https://www.w3.org/WAI/WCAG21/Techniques
-const ignoreTechniques = [`ARIA`, `C`, `F`, `G`, `H`].reduce((out, techniquePrefix) => {
-	let i = 1
-	while (i < 500) {
-		// Arbitrarily chosen number
-		const technique = `${techniquePrefix}${i}`
-		out.push(technique)
-		i++
-	}
-	return out
-}, [])
 const spellOptions = {
 	dictionary,
-	ignore: [...ignoreWords, ...ignoreTechniques],
+	ignore: getSpellIgnored(),
 }
 
 /**
@@ -100,4 +89,30 @@ function getCuratedMarkdownBody(body, options = {}) {
 	}
 
 	return removeMd(body)
+}
+
+/**
+ * Get a list of words for which spelling check should be ignored
+ * @returns {String[]}
+ */
+function getSpellIgnored() {
+	const ignoreConfigured = yaml.safeLoad(fs.readFileSync('./__tests__/spelling-ignore.yml', 'utf8'))
+
+	// https://www.w3.org/WAI/WCAG21/Techniques
+	const ignoreTechniques = [`ARIA`, `C`, `F`, `G`, `H`].reduce((out, techniquePrefix) => {
+		let i = 1
+		while (i < 500) {
+			// Arbitrarily chosen number
+			const technique = `${techniquePrefix}${i}`
+			out.push(technique)
+			i++
+		}
+		return out
+	}, [])
+
+	const ignoreAria = ariaQuery.aria.keys()
+	const ignoreDom = ariaQuery.dom.keys()
+	const ignoreRoles = ariaQuery.roles.keys()
+
+	return [...ignoreConfigured, ...ignoreTechniques, ...ignoreAria, ...ignoreDom, ...ignoreRoles]
 }

--- a/_rules/aria-attr-defined-5f99a7.md
+++ b/_rules/aria-attr-defined-5f99a7.md
@@ -86,11 +86,11 @@ Multiple valid ARIA 1.1 attributes `aria-*` are specified on element `input` wit
 
 #### Failed Example 2
 
-`aria-labelled` is not a defined attribute in ARIA 1.1.
+`aria-labelledby` is not a defined attribute in ARIA 1.1.
 
 ```html
 <span id="label">Birthday:</span>
-<div contenteditable role="searchbox" aria-labelled="label" aria-placeholder="MM-DD-YYYY">
+<div contenteditable role="searchbox" aria-labelledby="label" aria-placeholder="MM-DD-YYYY">
 	01-01-2019
 </div>
 ```

--- a/_rules/aria-attr-defined-5f99a7.md
+++ b/_rules/aria-attr-defined-5f99a7.md
@@ -86,11 +86,11 @@ Multiple valid ARIA 1.1 attributes `aria-*` are specified on element `input` wit
 
 #### Failed Example 2
 
-`aria-labelledby` is not a defined attribute in ARIA 1.1.
+`aria-labelled` is not a defined attribute in ARIA 1.1.
 
 ```html
 <span id="label">Birthday:</span>
-<div contenteditable role="searchbox" aria-labelledby="label" aria-placeholder="MM-DD-YYYY">
+<div contenteditable role="searchbox" aria-labelled="label" aria-placeholder="MM-DD-YYYY">
 	01-01-2019
 </div>
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -137,6 +137,25 @@
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
+		"@babel/runtime": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
+			"integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+			"dev": true,
+			"requires": {
+				"regenerator-runtime": "^0.13.2"
+			}
+		},
+		"@babel/runtime-corejs3": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.7.4.tgz",
+			"integrity": "sha512-BBIEhzk8McXDcB3IbOi8zQPzzINUp4zcLesVlBSOcyGhzPUU8Xezk5GAG7Sy5GVhGmAO0zGd2qRSeY2g4Obqxw==",
+			"dev": true,
+			"requires": {
+				"core-js-pure": "^3.0.0",
+				"regenerator-runtime": "^0.13.2"
+			}
+		},
 		"@babel/template": {
 			"version": "7.4.4",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
@@ -1071,6 +1090,16 @@
 				"sprintf-js": "~1.0.2"
 			}
 		},
+		"aria-query": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.0.0.tgz",
+			"integrity": "sha512-Tz7BL0lCASzlCrGOtf9dA2xCxtGMhRxIwL8J//3WX9uqSBqEaRqWwSOUdv5ZC7c2hf6UiaZXgVswWNILGmeugw==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.7.4",
+				"@babel/runtime-corejs3": "^7.7.4"
+			}
+		},
 		"arr-diff": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -1648,6 +1677,12 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+			"dev": true
+		},
+		"core-js-pure": {
+			"version": "3.4.5",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.4.5.tgz",
+			"integrity": "sha512-v3BoUOhmBvs4Z17jG/oM7qyv+tEEMvD1FYDDfxa6uD5W2rA/DpKvhvmyrBzxuMQTa/91UQKisaiqe0+0GuL2oA==",
 			"dev": true
 		},
 		"core-util-is": {
@@ -7239,6 +7274,12 @@
 			"requires": {
 				"util.promisify": "^1.0.0"
 			}
+		},
+		"regenerator-runtime": {
+			"version": "0.13.3",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+			"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+			"dev": true
 		},
 		"regex-not": {
 			"version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
 		"remove-markdown": "^0.3.0"
 	},
 	"devDependencies": {
+		"aria-query": "^4.0.0",
 		"dictionary-en-us": "^2.1.1",
 		"husky": "^3.0.9",
 		"jest": "^24.9.0",
@@ -135,11 +136,11 @@
 		"prettier": "^1.19.1",
 		"retext": "^7.0.1",
 		"retext-english": "^3.0.4",
+		"retext-redundant-acronyms": "^2.0.0",
 		"retext-repeated-words": "^2.0.0",
 		"retext-spell": "^3.0.0",
 		"retext-stringify": "^2.0.4",
 		"retext-syntax-urls": "^1.0.2",
-		"retext-redundant-acronyms": "^2.0.0",
 		"vfile-reporter": "^6.0.0"
 	},
 	"keywords": [


### PR DESCRIPTION
Use [aria-query](https://www.npmjs.com/package/aria-query) to filter out common `dom` tags, `aria` attributes and `roles` from spellcheck. This enable us to keep the manually updated spelling ignore list to a minimum.

Closes issue(s):
- https://github.com/act-rules/act-rules.github.io/issues/929