### PR TITLE
Remove --onlyChanged option for jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
 	"scripts": {
 		"formatRulesDir": "prettier --write './_rules/**/*.md'",
 		"format": "prettier --write *.{json,md,js,html,css,yml} './{__tests__,_rules,.github,pages,test-assets,test-utils,utils}/**/*.{json,md,js,html,css,yml}'",
-		"test": "jest --onlyChanged --coverage"
+		"test": "jest --coverage"
 	},
 	"homepage": "https://github.com/act-rules/act-rules.github.io",
 	"repository": {


### PR DESCRIPTION
The `--onlyChanged` option that was introduced in #1068 is messed up with our use case.
Proof: #1074 is passing the tests with "no file changed": https://github.com/act-rules/act-rules.github.io/pull/1074/checks?check_run_id=341598942#step:4:32

My bet is that the option only looks at `.js` files and ignore markdown, or something like that.

In any case, it needs to be removed asap. And given that the usual time for the test step is below 3min, we're not saving that much time…

Need for Final Call:
This can be merged with 1 approval (re-enabling test).