### PR TITLE
fix: add missing namespaces in xml example

### DIFF
--- a/_rules/attr-not-duplicated-e6952f.md
+++ b/_rules/attr-not-duplicated-e6952f.md
@@ -133,7 +133,11 @@ Code is XML, and not HTML or SVG.
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<earl:TestResult rdf:about="#result"></earl>
+<rdf:RDF
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:earl="http://www.w3.org/ns/earl#">
+  <earl:TestResult rdf:about="#result"></earl:TestResult>
+</rdf:RDF>
 ```
 
 #### Inapplicable Example 2


### PR DESCRIPTION
Necessary xml namespaces were missing in testcase example, hence preventing the page to render.

Closes issue(s):
- NA