### PR TITLE
fix: relative paths for test-assets in audio autoplay rule

### DIFF
--- a/_rules/auto-play-audio-does-not-exceed-3-seconds-aaa1bf.md
+++ b/_rules/auto-play-audio-does-not-exceed-3-seconds-aaa1bf.md
@@ -65,7 +65,7 @@ There are no major accessibility support issues known for this rule.
 The `<audio>` element does not play automatically for more than 3 seconds.
 
 ```html
-<audio src="../test-assets/moon-audio/moon-speech.mp3#t=25" autoplay="true"></audio>
+<audio src="/test-assets/moon-audio/moon-speech.mp3#t=25" autoplay="true"></audio>
 ```
 
 #### Passed Example 2
@@ -74,8 +74,8 @@ The `<video>` element audio output does not last longer than 3 seconds.
 
 ```html
 <video autoplay="true">
-	<source src="../test-assets/rabbit-video/video.mp4#t=8,10" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video.webm#t=8,10" type="video/webm" />
+	<source src="/test-assets/rabbit-video/video.mp4#t=8,10" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video.webm#t=8,10" type="video/webm" />
 </video>
 ```
 
@@ -86,7 +86,7 @@ The `<video>` element audio output does not last longer than 3 seconds.
 The `audio` element plays automatically for more than 3 seconds.
 
 ```html
-<audio src="../test-assets/moon-audio/moon-speech.mp3" autoplay="true" controls></audio>
+<audio src="/test-assets/moon-audio/moon-speech.mp3" autoplay="true" controls></audio>
 ```
 
 #### Failed Example 2
@@ -95,8 +95,8 @@ The `video` element automatically plays some audio for more than 3 seconds.
 
 ```html
 <video autoplay="true">
-	<source src="../test-assets/rabbit-video/video.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video.webm" type="video/webm" />
 </video>
 ```
 
@@ -108,8 +108,8 @@ The `video` element is `muted`.
 
 ```html
 <video autoplay="true" muted="true">
-	<source src="../test-assets/rabbit-video/video.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video.webm" type="video/webm" />
 </video>
 ```
 
@@ -119,8 +119,8 @@ The `video` element `src` file has no audio output.
 
 ```html
 <video autoplay="true">
-	<source src="../test-assets/rabbit-video/silent.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/silent.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/silent.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/silent.webm" type="video/webm" />
 </video>
 ```
 
@@ -129,5 +129,5 @@ The `video` element `src` file has no audio output.
 The `audio` element does not autoplay.
 
 ```html
-<audio src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
+<audio src="/test-assets/moon-audio/moon-speech.mp3" controls></audio>
 ```

--- a/_rules/auto-play-audio-has-control-mechanism-4c31df.md
+++ b/_rules/auto-play-audio-has-control-mechanism-4c31df.md
@@ -63,7 +63,7 @@ The native `<video>` and `<audio>` controls in several browser and assistive tec
 The `<audio>` element has a [mechanism](https://www.w3.org/TR/WCAG21/#dfn-mechanism) to pause or stop or turn the audio volume off.
 
 ```html
-<audio src="../test-assets/moon-audio/moon-speech.mp3" autoplay="true" controls></audio>
+<audio src="/test-assets/moon-audio/moon-speech.mp3" autoplay="true" controls></audio>
 ```
 
 #### Passed Example 2
@@ -72,8 +72,8 @@ The `<video>` element has a [mechanism](https://www.w3.org/TR/WCAG21/#dfn-mechan
 
 ```html
 <video autoplay="true" controls>
-	<source src="../test-assets/rabbit-video/video.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video.webm" type="video/webm" />
 </video>
 ```
 
@@ -99,8 +99,8 @@ The `<video>` element has a custom [mechanism](https://www.w3.org/TR/WCAG21/#dfn
 	<div id="video-container">
 		<!-- Video -->
 		<video id="video" autoplay="true">
-			<source src="https://act-rules.github.io/test-assets/rabbit-video/video.mp4" type="video/mp4" />
-			<source src="https://act-rules.github.io/test-assets/rabbit-video/video.webm" type="video/webm" />
+			<source src="/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+			<source src="/test-assets/rabbit-video/video.webm" type="video/webm" />
 		</video>
 		<!-- Video Controls -->
 		<div id="video-controls">
@@ -108,7 +108,7 @@ The `<video>` element has a custom [mechanism](https://www.w3.org/TR/WCAG21/#dfn
 			<button type="button" id="mute">Mute</button>
 		</div>
 	</div>
-	<script src="../test-assets/80f0bf/no-autoplay.js"></script>
+	<script src="/test-assets/80f0bf/no-autoplay.js"></script>
 </body>
 ```
 
@@ -119,7 +119,7 @@ The `<video>` element has a custom [mechanism](https://www.w3.org/TR/WCAG21/#dfn
 The `<audio>` does not have a [mechanism](https://www.w3.org/TR/WCAG21/#dfn-mechanism) to pause or stop or turn the audio volume off.
 
 ```html
-<audio src="../test-assets/moon-audio/moon-speech.mp3" autoplay="true"></audio>
+<audio src="/test-assets/moon-audio/moon-speech.mp3" autoplay="true"></audio>
 ```
 
 #### Failed Example 2
@@ -128,8 +128,8 @@ The `<video>` element autoplays and does not have a [mechanism](https://www.w3.o
 
 ```html
 <video autoplay="true">
-	<source src="../test-assets/rabbit-video/video.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video.webm" type="video/webm" />
 </video>
 ```
 
@@ -156,8 +156,8 @@ The `<video>` has a [mechanism](https://www.w3.org/TR/WCAG21/#dfn-mechanism) to 
 	<div id="video-container">
 		<!-- Video -->
 		<video id="video" autoplay="true">
-			<source src="../test-assets/rabbit-video/video.mp4" type="video/mp4" />
-			<source src="../test-assets/rabbit-video/video.webm" type="video/webm" />
+			<source src="/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+			<source src="/test-assets/rabbit-video/video.webm" type="video/webm" />
 		</video>
 		<!-- Video Controls -->
 		<div id="video-controls">
@@ -165,7 +165,7 @@ The `<video>` has a [mechanism](https://www.w3.org/TR/WCAG21/#dfn-mechanism) to 
 			<button type="button" id="mute">Mute</button>
 		</div>
 	</div>
-	<script src="../test-assets/80f0bf/no-autoplay.js"></script>
+	<script src="/test-assets/80f0bf/no-autoplay.js"></script>
 </body>
 ```
 
@@ -191,8 +191,8 @@ The `<video>` has a [mechanism](https://www.w3.org/TR/WCAG21/#dfn-mechanism) to 
 	<div id="video-container">
 		<!-- Video -->
 		<video id="video" autoplay="true">
-			<source src="../test-assets/rabbit-video/video.mp4" type="video/mp4" />
-			<source src="../test-assets/rabbit-video/video.webm" type="video/webm" />
+			<source src="/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+			<source src="/test-assets/rabbit-video/video.webm" type="video/webm" />
 		</video>
 		<!-- Video Controls -->
 		<div id="video-controls">
@@ -200,7 +200,7 @@ The `<video>` has a [mechanism](https://www.w3.org/TR/WCAG21/#dfn-mechanism) to 
 			<button type="button" id="mute"></button>
 		</div>
 	</div>
-	<script src="../test-assets/80f0bf/no-autoplay.js"></script>
+	<script src="/test-assets/80f0bf/no-autoplay.js"></script>
 </body>
 ```
 
@@ -226,8 +226,8 @@ The `<video>` has a [mechanism](https://www.w3.org/TR/WCAG21/#dfn-mechanism) to 
 	<div id="video-container">
 		<!-- Video -->
 		<video id="video" autoplay="true">
-			<source src="../test-assets/rabbit-video/video.mp4" type="video/mp4" />
-			<source src="../test-assets/rabbit-video/video.webm" type="video/webm" />
+			<source src="/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+			<source src="/test-assets/rabbit-video/video.webm" type="video/webm" />
 		</video>
 		<!-- Video Controls -->
 		<div id="video-controls" aria-hidden="true">
@@ -235,7 +235,7 @@ The `<video>` has a [mechanism](https://www.w3.org/TR/WCAG21/#dfn-mechanism) to 
 			<button type="button" id="mute">Mute</button>
 		</div>
 	</div>
-	<script src="../test-assets/80f0bf/no-autoplay.js"></script>
+	<script src="/test-assets/80f0bf/no-autoplay.js"></script>
 </body>
 ```
 
@@ -247,8 +247,8 @@ The `<video>` element is `muted`.
 
 ```html
 <video autoplay="true" muted="true">
-	<source src="../test-assets/rabbit-video/video.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video.webm" type="video/webm" />
 </video>
 ```
 
@@ -258,8 +258,8 @@ The `<video>` element `src` file has no audio output.
 
 ```html
 <video autoplay="true">
-	<source src="../test-assets/rabbit-video/video-with-incorrect-voiceover.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video-with-incorrect-voiceover.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/video-with-incorrect-voiceover.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video-with-incorrect-voiceover.webm" type="video/webm" />
 </video>
 ```
 
@@ -268,5 +268,5 @@ The `<video>` element `src` file has no audio output.
 The `audio` element does not autoplay.
 
 ```html
-<audio src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
+<audio src="/test-assets/moon-audio/moon-speech.mp3" controls></audio>
 ```

--- a/_rules/no-auto-play-audio-80f0bf.md
+++ b/_rules/no-auto-play-audio-80f0bf.md
@@ -64,7 +64,7 @@ The native `<video>` and `<audio>` controls in several browser and assistive tec
 The `<audio>` element has a [mechanism](https://www.w3.org/TR/WCAG21/#dfn-mechanism) to pause or stop or turn the audio volume off.
 
 ```html
-<audio src="../test-assets/moon-audio/moon-speech.mp3" autoplay="true" controls></audio>
+<audio src="/test-assets/moon-audio/moon-speech.mp3" autoplay="true" controls></audio>
 ```
 
 #### Passed Example 2
@@ -73,8 +73,8 @@ The `<video>` element does not play for longer than 3 seconds.
 
 ```html
 <video autoplay="true">
-	<source src="../test-assets/rabbit-video/video.mp4#t=8,10" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video.webm#t=8,10" type="video/webm" />
+	<source src="/test-assets/rabbit-video/video.mp4#t=8,10" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video.webm#t=8,10" type="video/webm" />
 </video>
 ```
 
@@ -100,8 +100,8 @@ The `<video>` element autoplays, and has a [mechanism](https://www.w3.org/TR/WCA
 	<div id="video-container">
 		<!-- Video -->
 		<video id="video" autoplay="true">
-			<source src="https://act-rules.github.io/test-assets/rabbit-video/video.mp4" type="video/mp4" />
-			<source src="https://act-rules.github.io/test-assets/rabbit-video/video.webm" type="video/webm" />
+			<source src="/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+			<source src="/test-assets/rabbit-video/video.webm" type="video/webm" />
 		</video>
 		<!-- Video Controls -->
 		<div id="video-controls">
@@ -109,7 +109,7 @@ The `<video>` element autoplays, and has a [mechanism](https://www.w3.org/TR/WCA
 			<button type="button" id="mute">Mute</button>
 		</div>
 	</div>
-	<script src="../test-assets/80f0bf/no-autoplay.js"></script>
+	<script src="/test-assets/80f0bf/no-autoplay.js"></script>
 </body>
 ```
 
@@ -120,7 +120,7 @@ The `<video>` element autoplays, and has a [mechanism](https://www.w3.org/TR/WCA
 The `<audio>` element autoplays, lasts for more than 3 seconds, and does not have a [mechanism](https://www.w3.org/TR/WCAG21/#dfn-mechanism) to pause or stop or turn the audio volume off.
 
 ```html
-<audio src="../test-assets/moon-audio/moon-speech.mp3" autoplay="true"></audio>
+<audio src="/test-assets/moon-audio/moon-speech.mp3" autoplay="true"></audio>
 ```
 
 #### Failed Example 2
@@ -129,8 +129,8 @@ The `<video>` element audio autoplays for longer than 3 seconds, and does not ha
 
 ```html
 <video autoplay="true">
-	<source src="../test-assets/rabbit-video/video.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video.webm" type="video/webm" />
 </video>
 ```
 
@@ -142,8 +142,8 @@ The `<video>` element audio autoplays for longer than 3 seconds, but is `muted`.
 
 ```html
 <video autoplay="true" muted="true">
-	<source src="../test-assets/rabbit-video/video.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/video.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/video.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/video.webm" type="video/webm" />
 </video>
 ```
 
@@ -153,8 +153,8 @@ The `<video>` element has no audio output.
 
 ```html
 <video autoplay="true">
-	<source src="../test-assets/rabbit-video/silent.mp4" type="video/mp4" />
-	<source src="../test-assets/rabbit-video/silent.webm" type="video/webm" />
+	<source src="/test-assets/rabbit-video/silent.mp4" type="video/mp4" />
+	<source src="/test-assets/rabbit-video/silent.webm" type="video/webm" />
 </video>
 ```
 
@@ -163,5 +163,5 @@ The `<video>` element has no audio output.
 The `audio` element does not play automatically.
 
 ```html
-<audio src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
+<audio src="/test-assets/moon-audio/moon-speech.mp3" controls></audio>
 ```


### PR DESCRIPTION
- relative paths for test-assets in audio autoplay rule

Closes issue(s):

- NA