### PR TITLE
iframe has title; remove background link

### DIFF
--- a/_rules/iframe-accessible-name-cae760.md
+++ b/_rules/iframe-accessible-name-cae760.md
@@ -40,7 +40,6 @@ _There are no major accessibility support issues known for this rule._
 
 - [H64: Using the title attribute of the frame and iframe elements](https://www.w3.org/WAI/WCAG21/Techniques/html/H64)
 - [Understanding Success Criterion 4.1.2](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html)
-- [Understanding Success Criterion 2.4.1](https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks.html)
 - [User interface component](https://www.w3.org/TR/WCAG21/#dfn-user-interface-components)
 
 ## Test Cases


### PR DESCRIPTION
This was requested by the ACT Task Force. Iframes have very little to do with 2.4.1. The connection is unusual at best. We're also going to raise an issue with AG to remove 2.4.1 from H64 because it is confusing.

Need for Final Call: nope