### PR TITLE
chore: note that acc name testing is out of scope

### DIFF
--- a/_rules/button-accessible-name-97a4e1.md
+++ b/_rules/button-accessible-name-97a4e1.md
@@ -29,6 +29,8 @@ Each target element has an [accessible name][] that is not empty (`""`).
 
 **Note**: `input` elements of type `submit` and `reset` can get their [accessible name][] from a [default text](https://www.w3.org/TR/html-aam/#input-type-button-input-type-submit-and-input-type-reset), as well as from a `value` or other attribute.
 
+**Note**: Testing that the [accessible name][] is descriptive is not part of this rule and must be tested separately.
+
 ## Assumptions
 
 - The rule assumes that all buttons are [user interface components as defined by WCAG 2](https://www.w3.org/TR/WCAG21/#dfn-user-interface-components).

--- a/_rules/explicit-SVG-image-has-name-7d6734.md
+++ b/_rules/explicit-SVG-image-has-name-7d6734.md
@@ -26,7 +26,9 @@ The rule applies to any element in the [SVG](https://www.w3.org/2000/svg) namesp
 
 ## Expectation
 
-Each target element has an [accessible name](#accessible-name) that is not empty.
+Each target element has an [accessible name][] that is not empty.
+
+**Note**: Testing that the [accessible name][] is descriptive is not part of this rule and must be tested separately.
 
 ## Assumptions
 
@@ -57,7 +59,7 @@ Until browser support for the [SVG Accessibility API Mappings](https://www.w3.or
 
 #### Passed Example 1
 
-The `svg` element has an explicit role of `img` and an accessible name from the `title` element that is not empty.
+The `svg` element has an explicit role of `img` and an [accessible name][] from the `title` element that is not empty.
 
 ```html
 <p>How many circles are there?</p>
@@ -69,7 +71,7 @@ The `svg` element has an explicit role of `img` and an accessible name from the 
 
 #### Passed Example 2
 
-The `circle` element has an explicit role of `graphics-symbol` and an accessible name from the `aria-label` attribute that is not empty.
+The `circle` element has an explicit role of `graphics-symbol` and an [accessible name][] from the `aria-label` attribute that is not empty.
 
 ```html
 <p>How many circles are there?</p>
@@ -89,7 +91,7 @@ The `circle` element has an explicit role of `graphics-symbol` and an accessible
 
 #### Passed Example 3
 
-The `svg` element has an explicit role of `graphics-document` and an accessible name from the `title` element that is not empty.
+The `svg` element has an explicit role of `graphics-document` and an [accessible name][] from the `title` element that is not empty.
 
 ```html
 <p>How many circles are there?</p>
@@ -103,7 +105,7 @@ The `svg` element has an explicit role of `graphics-document` and an accessible 
 
 #### Failed Example 1
 
-The `svg` element has an explicit role of `img` but has no accessible name.
+The `svg` element has an explicit role of `img` but has no [accessible name][].
 
 ```html
 <p>How many circles are there?</p>
@@ -114,7 +116,7 @@ The `svg` element has an explicit role of `img` but has no accessible name.
 
 #### Failed Example 2
 
-The `svg` element has an explicit role of `img` but has only whitespace in the `title` element for the accessible name.
+The `svg` element has an explicit role of `img` but has only whitespace in the `title` element for the [accessible name][].
 
 ```html
 <p>How many circles are there?</p>
@@ -126,7 +128,7 @@ The `svg` element has an explicit role of `img` but has only whitespace in the `
 
 #### Failed Example 3
 
-The `svg` element has an explicit role of `img`, is included in the accessibility tree, but it has no accessible name because the `title` element is empty.
+The `svg` element has an explicit role of `img`, is included in the accessibility tree, but it has no [accessible name][] because the `title` element is empty.
 
 ```html
 <p>How many circles are there?</p>
@@ -138,7 +140,7 @@ The `svg` element has an explicit role of `img`, is included in the accessibilit
 
 #### Failed Example 4
 
-The `circle` element has an explicit role of `graphics-symbol` but does not have an accessible name.
+The `circle` element has an explicit role of `graphics-symbol` but does not have an [accessible name][].
 
 ```html
 <p>How many circles are there?</p>
@@ -178,3 +180,5 @@ The `circle` element has an explicit role that is neither `img`, `graphics-docum
 	<circle role="graphics-object" cx="50" cy="50" r="40" fill="yellow"></circle>
 </svg>
 ```
+
+[accessible name]: #accessible-name 'Definition of accessible name'

--- a/_rules/form-control-accessible-name-e086e5.md
+++ b/_rules/form-control-accessible-name-e086e5.md
@@ -33,6 +33,8 @@ This rule applies to any element that is [included in the accessibility tree](#i
 
 Each target element has an [accessible name][] that is not empty (`""`).
 
+**Note**: Testing that the [accessible name][] is descriptive is not part of this rule and must be tested separately.
+
 ## Assumptions
 
 _There are currently no assumptions_

--- a/_rules/iframe-accessible-name-cae760.md
+++ b/_rules/iframe-accessible-name-cae760.md
@@ -28,6 +28,8 @@ The rule applies to `iframe` elements that are [included in the accessibility tr
 
 Each target element has an [accessible name][] that is not empty (`""`).
 
+**Note**: Testing that the [accessible name][] is descriptive is not part of this rule and must be tested separately.
+
 ## Assumptions
 
 - The rule assumes that the target `iframe` is used as a [user interface component](https://www.w3.org/TR/WCAG21/#dfn-user-interface-components).

--- a/_rules/image-accessible-name-23a2a8.md
+++ b/_rules/image-accessible-name-23a2a8.md
@@ -31,7 +31,9 @@ The rule applies to HTML `img` elements or any HTML element with the [semantic r
 
 Each target element has an [accessible name][] that is not empty (`""`), or is marked as [decorative][].
 
-**NOTE**: An `img` element can be marked as [decorative][], by using either `role="presentation"`, `role="none"` or an empty `alt` attribute, (`alt=""` or `alt` with no value).
+**Note**: An `img` element can be marked as [decorative][], by using either `role="presentation"`, `role="none"` or an empty `alt` attribute, (`alt=""` or `alt` with no value).
+
+**Note**: Testing that the [accessible name][] is descriptive is not part of this rule and must be tested separately.
 
 ## Assumptions
 

--- a/_rules/image-button-accessible-name-59796f.md
+++ b/_rules/image-button-accessible-name-59796f.md
@@ -37,6 +37,8 @@ The rule applies to any HTML `input` element with a `type` attribute in the `Ima
 
 Each target element has an [accessible name][] that is not empty (`""`).
 
+**Note**: Testing that the [accessible name][] is descriptive is not part of this rule and must be tested separately.
+
 ## Assumptions
 
 - This rule assumes that all image buttons are [user interface components as defined by WCAG 2](https://www.w3.org/TR/WCAG21/#dfn-user-interface-components).

--- a/_rules/link-accessible-name-c487ae.md
+++ b/_rules/link-accessible-name-c487ae.md
@@ -41,6 +41,8 @@ The rule applies to any HTML element with the [semantic role](#semantic-role) of
 
 Each target element has an [accessible name][] that is not empty (`""`).
 
+**Note**: Testing that the [accessible name][] is descriptive is not part of this rule and must be tested separately.
+
 ## Assumptions
 
 - The rule assumes that all links are [user interface components](https://www.w3.org/TR/WCAG21/#dfn-user-interface-components) as defined by WCAG 2. When the link role is used incorrectly, this assumption may not be true.


### PR DESCRIPTION
This change was requested by the ACT Task Force. They wanted it to be clearer that accessible names have to be tested separately from testing those the accessible name exists.


Need for Final Call: none