### PR TITLE
editorial: update rule titles in expectation

### DIFF
--- a/_rules/audio-text-alternative-e7aa44.md
+++ b/_rules/audio-text-alternative-e7aa44.md
@@ -39,8 +39,8 @@ The rule applies to any [non-streaming](#non-streaming-media-element) `audio` el
 
 For each test target, the [outcome](#outcome) of at least one of the following rules is passed:
 
-- [Audio elements have a transcript](https://act-rules.github.io/rules/2eb176)
-- [Audio-only as a media alternative for text](https://act-rules.github.io/rules/afb423)
+- [`Audio` Element Content Has Transcript](https://act-rules.github.io/rules/2eb176)
+- [`Audio` Element Content Is Media Alternative For Text](https://act-rules.github.io/rules/afb423)
 
 ## Assumptions
 

--- a/_rules/focusable-no-keyboard-trap-80af7b.md
+++ b/_rules/focusable-no-keyboard-trap-80af7b.md
@@ -30,8 +30,8 @@ The rule only applies to any HTML or SVG element that is [focusable][].
 
 For each test target, the [outcome](#outcome) of one of the following rules is "passed":
 
-- [No keyboard trap standard navigation](https://act-rules.github.io/rules/a1b64e)
-- [No keyboard trap non-standard navigation](https://act-rules.github.io/rules/ebe86a)
+- [Focusable Element Has No Keyboard Trap Via Standard Navigation](https://act-rules.github.io/rules/a1b64e)
+- [Focusable Element Has No Keyboard Trap Via Non-Standard Navigation](https://act-rules.github.io/rules/ebe86a)
 
 ## Assumptions
 

--- a/_rules/no-auto-play-audio-80f0bf.md
+++ b/_rules/no-auto-play-audio-80f0bf.md
@@ -39,8 +39,8 @@ The default value of both `paused` and `muted` attributes is `false`.
 
 For each test target, the outcome of at least one of the following rules is passed:
 
-- [audio or video that plays automatically has a control mechanism](https://act-rules.github.io/rules/4c31df)
-- [audio or video that plays automatically does not exceed 3 seconds](https://act-rules.github.io/rules/aaa1bf)
+- [Audio Or Video That Plays Automatically Has A Control Mechanism](https://act-rules.github.io/rules/4c31df)
+- [Audio Or Video That Plays Automatically Does Not Exceed 3 Seconds](https://act-rules.github.io/rules/aaa1bf)
 
 ## Assumptions
 

--- a/_rules/video-alternative-for-auditory-eac66b.md
+++ b/_rules/video-alternative-for-auditory-eac66b.md
@@ -27,8 +27,8 @@ The rule applies to every [non-streaming](#non-streaming-media-element) `video` 
 
 For each test target, the [outcome](#outcome) of at least one of the following rules is passed:
 
-- [Video as a media alternative for text](https://act-rules.github.io/rules/ab4d13)
-- [Video has captions](https://act-rules.github.io/rules/f51b46)
+- [`Video` Element Content Is Media Alternative For Text](https://act-rules.github.io/rules/ab4d13)
+- [`Video` Element Auditory Content Has Captions](https://act-rules.github.io/rules/f51b46)
 
 ## Assumptions
 

--- a/_rules/video-alternative-for-visual-c5a4ea.md
+++ b/_rules/video-alternative-for-visual-c5a4ea.md
@@ -31,10 +31,10 @@ The rule applies to every [non-streaming](#non-streaming-media-element) `video` 
 
 For each test target, the [outcome](#outcome) of at least one of the following rules is passed:
 
-- [Video element audio described](https://act-rules.github.io/rules/1ea59c)
-- [Video element transcript](https://act-rules.github.io/rules/1a02b0)
-- [Video element description track](https://act-rules.github.io/rules/f196ce)
-- [Video as a media alternative for text](https://act-rules.github.io/rules/ab4d13)
+- [`Video` Element Visual Content Has Audio Description](https://act-rules.github.io/rules/1ea59c)
+- [`Video` Element Visual Content Has Transcript](https://act-rules.github.io/rules/1a02b0)
+- [`Video` Element Visual Content Has Description Track](https://act-rules.github.io/rules/f196ce)
+- [`Video` Element Content Is Media Alternative For Text](https://act-rules.github.io/rules/ab4d13)
 
 ## Assumptions
 

--- a/_rules/video-only-alternative-for-visual-c3232f.md
+++ b/_rules/video-only-alternative-for-visual-c3232f.md
@@ -35,10 +35,10 @@ The rule applies to any [non-streaming](#non-streaming-media-element) `video` el
 
 For each test target, the [outcome](#outcome) of at least one of the following rules is passed:
 
-- [Video-Only As A Media Alternative For Text](https://act-rules.github.io/rules/fd26cf)
-- [Video Only Element Has Description Track](https://act-rules.github.io/rules/ac7dc6)
-- [Video Only Element Has Transcript](https://act-rules.github.io/rules/ee13b5)
-- [Video Has Audio Alternative](https://act-rules.github.io/rules/eac66b)
+- [`Video` Element Visual-Only Content Is Media Alternative For Text](https://act-rules.github.io/rules/fd26cf)
+- [`Video` Element Visual-Only Content Has Description Track](https://act-rules.github.io/rules/ac7dc6)
+- [`Video` Element Visual-Only Content Has Transcript](https://act-rules.github.io/rules/ee13b5)
+- [`Video` Element Visual-Only Content Has Audio Track Alternative](https://act-rules.github.io/rules/d7ba54)
 
 ## Assumptions
 

--- a/_rules/video-strict-alternative-for-visual-1ec09b.md
+++ b/_rules/video-strict-alternative-for-visual-1ec09b.md
@@ -28,8 +28,7 @@ The rule applies to every [non-streaming](#non-streaming-media-element) `video` 
 
 For each test target, the [outcome](#outcome) of at least one of the following rules is passed:
 
-- [`Video` Element Visual Content Has Audio Description
-  ](https://act-rules.github.io/rules/1ea59c)
+- [`Video` Element Visual Content Has Audio Description](https://act-rules.github.io/rules/1ea59c)
 - [`Video` Element Content Is Media Alternative For Text](https://act-rules.github.io/rules/ab4d13)
 - [`Video` Element Visual Content Has Description Track](https://act-rules.github.io/rules/f196ce)
 

--- a/_rules/video-strict-alternative-for-visual-1ec09b.md
+++ b/_rules/video-strict-alternative-for-visual-1ec09b.md
@@ -28,9 +28,10 @@ The rule applies to every [non-streaming](#non-streaming-media-element) `video` 
 
 For each test target, the [outcome](#outcome) of at least one of the following rules is passed:
 
-- [Video element audio described](https://act-rules.github.io/rules/1ea59c)
-- [Video element description track](https://act-rules.github.io/rules/f196ce)
-- [Video as a media alternative for text](https://act-rules.github.io/rules/ab4d13)
+- [`Video` Element Visual Content Has Audio Description
+  ](https://act-rules.github.io/rules/1ea59c)
+- [`Video` Element Content Is Media Alternative For Text](https://act-rules.github.io/rules/ab4d13)
+- [`Video` Element Visual Content Has Description Track](https://act-rules.github.io/rules/f196ce)
 
 ## Assumptions
 


### PR DESCRIPTION
@DagfinnRomen reported that one of the rules had the wrong link. I fixed that, plus I updated the titles

Closes issue(s): none