### PR TITLE
Add link to "image button state" for clarity (59796f)

### DIFF
--- a/_rules/image-button-accessible-name-59796f.md
+++ b/_rules/image-button-accessible-name-59796f.md
@@ -29,7 +29,7 @@ htmlHintIgnore:
 
 ## Applicability
 
-The rule applies to any HTML `input` element with a `type` attribute in the `Image Button` state, that is [included in the accessibility tree][].
+The rule applies to any HTML `input` element with a `type` attribute in the [`Image Button` state](<https://html.spec.whatwg.org/#image-button-state-(type=image)>), that is [included in the accessibility tree][].
 
 **Note:** The specification of the [`type`](https://html.spec.whatwg.org/#states-of-the-type-attribute) attribute describes in detail how to map the value of the attribute to its corresponding state.
 


### PR DESCRIPTION
Add a link to the definition of "`image button` state" to clarify that `type="image"` does that.

Closes issue(s):
- #1065 

Need for Final Call:
This will not require a Final Call (adding a link without changing text).

---

## Pull Request Etiquette

### **When creating PR:**

- Make sure you requesting to **pull a branch** (right side) to the `develop` branch (left side).

### **After creating PR:**

- Add yourself (and co-authors) as "Assignees" for PR.
- Add label to indicate if it's a `Rule`, `Definition` or `Chore`.
- Close the issue that the PR resolves (and make sure the issue is referenced in the top of this comment)
- Optionally request feedback from anyone in particular by assigning them as "Reviewers".

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Final Call period. In case of disagreement, the longer period wins.
