### PR TITLE
chore: add git lfs support to track large files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.zip filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
When the website is [published](https://github.com/act-rules/act-rules-web/blob/master/.github/workflows/publish.yml#L42), there are some large files which needs to be git tracked. 

Closes issue(s):
- NA

Need for Final Call: No

