### PR TITLE
Unifying boldness of colons in "Note:"

### DIFF
--- a/_rules/aria-hidden-no-focusable-content-6cfa84.md
+++ b/_rules/aria-hidden-no-focusable-content-6cfa84.md
@@ -33,7 +33,7 @@ acknowledgements:
 
 The rule applies to any element with an `aria-hidden="true"` attribute.
 
-**Note**: Using `aria-hidden="false"` on a descendant of an element with `aria-hidden="true"` **does not** expose that element. `aria-hidden="true"` hides itself and all its content from assistive technologies.
+**Note:** Using `aria-hidden="false"` on a descendant of an element with `aria-hidden="true"` **does not** expose that element. `aria-hidden="true"` hides itself and all its content from assistive technologies.
 
 ## Expectation
 

--- a/_rules/audio-transcript-2eb176.md
+++ b/_rules/audio-transcript-2eb176.md
@@ -28,7 +28,7 @@ The rule applies to every [non-streaming](#non-streaming-media-element) `audio` 
 
 The auditory information of each test target is available through a text transcript. That text transcript is [visible][] and [included in the accessibility tree][], either on the page or through a link.
 
-**Note**: A "text transcript" in the context of this rule is defined in WCAG 2 as an [alternative for time based media](https://www.w3.org/TR/WCAG21/#dfn-alternative-for-time-based-media).
+**Note:** A "text transcript" in the context of this rule is defined in WCAG 2 as an [alternative for time based media](https://www.w3.org/TR/WCAG21/#dfn-alternative-for-time-based-media).
 
 ## Assumptions
 

--- a/_rules/auto-play-audio-does-not-exceed-3-seconds-aaa1bf.md
+++ b/_rules/auto-play-audio-does-not-exceed-3-seconds-aaa1bf.md
@@ -29,7 +29,7 @@ This rule applies to any `audio` or `video` element that has:
 - both `paused` and `muted` attributes equal to false, and
 - either a `src` attribute or a child `source` element that references content with a duration of more than 3 seconds that contains audio.
 
-**Note**:
+**Note:**
 
 The default value of both `paused` and `muted` attributes is `false`.
 
@@ -37,7 +37,7 @@ The default value of both `paused` and `muted` attributes is `false`.
 
 For each test target the total audio output does not last more than 3 seconds.
 
-**Note**:
+**Note:**
 
 This rule does not cover single audio instances that play repeatedly for more than three seconds, or multiple audio instances for more than three seconds. The [WCAG Understanding documentation for 1.4.2 Audio Controls](https://www.w3.org/WAI/WCAG21/Understanding/audio-control.html) is ambiguous about how to handle these scenarios.
 

--- a/_rules/auto-play-audio-has-control-mechanism-4c31df.md
+++ b/_rules/auto-play-audio-has-control-mechanism-4c31df.md
@@ -28,7 +28,7 @@ This rule applies to any `audio` or `video` element that has:
 - both `paused` and `muted` attributes equal to false, and
 - either a `src` attribute or a child `source` element that references content with a duration of more than 3 seconds that contains audio.
 
-**Note**:
+**Note:**
 
 The default value of both `paused` and `muted` attributes is `false`.
 

--- a/_rules/autocomplete-valid-value-73f2c2.md
+++ b/_rules/autocomplete-valid-value-73f2c2.md
@@ -40,7 +40,7 @@ The autocomplete term(s) follow the [HTML 5.2 specification](https://www.w3.org/
 3. Has either "home", "work", "mobile", "fax" or "pager" _(optional, only for "email", "impp", "tel" or "tel-\*")_
 4. Has a [correct autocomplete field](#correct-autocomplete-field) _(required)_
 
-**Note**: Autocomplete terms are case insensitive. When multiple terms are used, they must be used in the correct order.
+**Note:** Autocomplete terms are case insensitive. When multiple terms are used, they must be used in the correct order.
 
 ## Expectation 3
 

--- a/_rules/button-accessible-name-97a4e1.md
+++ b/_rules/button-accessible-name-97a4e1.md
@@ -29,9 +29,9 @@ The rule applies to elements that are [included in the accessibility tree][] and
 
 Each target element has an [accessible name][] that is not empty (`""`).
 
-**Note**: `input` elements of type `submit` and `reset` can get their [accessible name][] from a [default text](https://www.w3.org/TR/html-aam/#input-type-button-input-type-submit-and-input-type-reset), as well as from a `value` or other attribute.
+**Note:** `input` elements of type `submit` and `reset` can get their [accessible name][] from a [default text](https://www.w3.org/TR/html-aam/#input-type-button-input-type-submit-and-input-type-reset), as well as from a `value` or other attribute.
 
-**Note**: Testing that the [accessible name][] is descriptive is not part of this rule and must be tested separately.
+**Note:** Testing that the [accessible name][] is descriptive is not part of this rule and must be tested separately.
 
 ## Assumptions
 

--- a/_rules/explicit-SVG-image-has-name-7d6734.md
+++ b/_rules/explicit-SVG-image-has-name-7d6734.md
@@ -22,13 +22,13 @@ acknowledgements:
 
 The rule applies to any element in the [SVG](https://www.w3.org/2000/svg) namespace with an [explicit semantic role](#explicit-role) of either `img`, `graphics-document`, `graphics-symbol`, that is [included in the accessibility tree](#included-in-the-accessibility-tree).
 
-**Note**: The [SVG Accessibility API Mappings](https://www.w3.org/TR/svg-aam-1.0/#include_elements) specifies that many elements in the SVG namespace are purely presentational and should not be included in the accessibility tree unless indicated otherwise through the use of text alternative content, an explicit WAI ARIA role, or a valid `tabindex` attribute.
+**Note:** The [SVG Accessibility API Mappings](https://www.w3.org/TR/svg-aam-1.0/#include_elements) specifies that many elements in the SVG namespace are purely presentational and should not be included in the accessibility tree unless indicated otherwise through the use of text alternative content, an explicit WAI ARIA role, or a valid `tabindex` attribute.
 
 ## Expectation
 
 Each target element has an [accessible name][] that is not empty.
 
-**Note**: Testing that the [accessible name][] is descriptive is not part of this rule and must be tested separately.
+**Note:** Testing that the [accessible name][] is descriptive is not part of this rule and must be tested separately.
 
 ## Assumptions
 

--- a/_rules/focusable-no-keyboard-trap-80af7b.md
+++ b/_rules/focusable-no-keyboard-trap-80af7b.md
@@ -24,7 +24,7 @@ acknowledgements:
 
 The rule only applies to any HTML or SVG element that is [focusable][].
 
-**Note**: This rule only applies to HTML and SVG. Thus, it is a partial check for WCAG 2.0 success criterion 2.1.2, which applies to all content.
+**Note:** This rule only applies to HTML and SVG. Thus, it is a partial check for WCAG 2.0 success criterion 2.1.2, which applies to all content.
 
 ## Expectation
 

--- a/_rules/focusable-no-keyboard-trap-non-standard-nav-ebe86a.md
+++ b/_rules/focusable-no-keyboard-trap-non-standard-nav-ebe86a.md
@@ -23,13 +23,13 @@ acknowledgements:
 
 The rule applies to any HTML or SVG element that is [focusable](#focusable) where focus cannot cycle to the browser UI by using [standard keyboard navigation](#standard-keyboard-navigation).
 
-**Note**: This rule only applies to HTML and SVG. Thus, it is a partial check for WCAG 2.0 success criterion 2.1.2, which applies to all content.
+**Note:** This rule only applies to HTML and SVG. Thus, it is a partial check for WCAG 2.0 success criterion 2.1.2, which applies to all content.
 
 ## Expectation 1
 
 For each target element help information is [visible](#visible) and [included in the accessibility tree](#included-in-the-accessibility-tree) or can be accessed from within the keyboard trap.
 
-**Note**: As per WCAG 2.0 Success Criterion 2.1.1 Keyboard the help information should be accessible through a keyboard interface.
+**Note:** As per WCAG 2.0 Success Criterion 2.1.1 Keyboard the help information should be accessible through a keyboard interface.
 
 ## Expectation 2
 
@@ -39,7 +39,7 @@ The help information explains how to cycle to the browser UI, or on how to get t
 
 For each target element focus can cycle to the browser UI by using the method advised in the help information.
 
-**Note**: Cycling back to the browser UI can be done both by moving forward through the tab order and by moving backwards. It is not possible to fulfill this expectation by using browser specific shortcuts to return to the browser UI.
+**Note:** Cycling back to the browser UI can be done both by moving forward through the tab order and by moving backwards. It is not possible to fulfill this expectation by using browser specific shortcuts to return to the browser UI.
 
 ## Assumptions
 

--- a/_rules/focusable-no-keyboard-trap-standard-nav-a1b64e.md
+++ b/_rules/focusable-no-keyboard-trap-standard-nav-a1b64e.md
@@ -23,13 +23,13 @@ acknowledgements:
 
 The rule applies to any HTML or SVG element that is [focusable][].
 
-**Note**: This rule only applies to HTML and SVG. Thus, it is a partial check for WCAG 2.0 success criterion 2.1.2, which applies to all content.
+**Note:** This rule only applies to HTML and SVG. Thus, it is a partial check for WCAG 2.0 success criterion 2.1.2, which applies to all content.
 
 ## Expectation
 
 For each target element focus can cycle to the browser UI by using [standard keyboard navigation](#standard-keyboard-navigation).
 
-**Note**: Cycling back to the browser UI can be done both by moving forward through the tab order and by moving backwards. It is not possible to fulfill this expectation by using browser specific shortcuts to return to the browser UI.
+**Note:** Cycling back to the browser UI can be done both by moving forward through the tab order and by moving backwards. It is not possible to fulfill this expectation by using browser specific shortcuts to return to the browser UI.
 
 ## Assumptions
 

--- a/_rules/form-control-accessible-name-e086e5.md
+++ b/_rules/form-control-accessible-name-e086e5.md
@@ -22,18 +22,18 @@ acknowledgements:
 
 This rule applies to any element that is [included in the accessibility tree](#included-in-the-accessibility-tree), and that has one of the following [semantic roles][]: `checkbox`, `combobox` (`select` elements), `listbox`, `menuitemcheckbox`, `menuitemradio`, `radio`, `searchbox`, `slider`, `spinbutton`, `switch`, `textbox`.
 
-**Note**: The list of roles is derived by taking all the roles from [WAI-ARIA Specifications](#wai-aria-specifications) that:
+**Note:** The list of roles is derived by taking all the roles from [WAI-ARIA Specifications](#wai-aria-specifications) that:
 
 - have a [semantic roles][] that inherits from the [abstract](https://www.w3.org/TR/wai-aria/#abstract_roles) `input` or `select` role, and
 - does not have a [required context](https://www.w3.org/TR/wai-aria/#scope) role that itself inherits from one of those roles.
 
-**Note**: The `option` role is not part of the list of applicable roles, because it does not meet the definition of a [User interface component](https://www.w3.org/TR/WCAG21/#dfn-user-interface-components). This means [WCAG 2.1](https://www.w3.org/TR/WCAG21/) does not require it to have an [accessible name][].
+**Note:** The `option` role is not part of the list of applicable roles, because it does not meet the definition of a [User interface component](https://www.w3.org/TR/WCAG21/#dfn-user-interface-components). This means [WCAG 2.1](https://www.w3.org/TR/WCAG21/) does not require it to have an [accessible name][].
 
 ## Expectation
 
 Each target element has an [accessible name][] that is not empty (`""`).
 
-**Note**: Testing that the [accessible name][] is descriptive is not part of this rule and must be tested separately.
+**Note:** Testing that the [accessible name][] is descriptive is not part of this rule and must be tested separately.
 
 ## Assumptions
 
@@ -48,7 +48,7 @@ Certain assistive technologies can be set up to ignore the title attribute, whic
 - [Understanding Success Criterion 3.3.2: Labels or Instructions](https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions)
 - [Understanding Success Criterion 4.1.2: Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value)
 
-**Note**: This rule does not fail 3.3.2 as there are sufficient techniques within 3.3.2 that don't need the elements to have an [accessible name][]. For example "G131: Providing descriptive labels" **AND** "G162: Positioning labels to maximize predictability of relationships" would be sufficient.
+**Note:** This rule does not fail 3.3.2 as there are sufficient techniques within 3.3.2 that don't need the elements to have an [accessible name][]. For example "G131: Providing descriptive labels" **AND** "G162: Positioning labels to maximize predictability of relationships" would be sufficient.
 
 ## Test Cases
 

--- a/_rules/form-control-label-descriptive-cc0f0a.md
+++ b/_rules/form-control-label-descriptive-cc0f0a.md
@@ -36,19 +36,19 @@ This rule applies to any HTML `label` element or other element referenced by `ar
 - `switch`
 - `textbox`
 
-**Note**: The list of form field roles is derived by taking all the roles from [WAI-ARIA Specifications](#wai-aria-specifications) that:
+**Note:** The list of form field roles is derived by taking all the roles from [WAI-ARIA Specifications](#wai-aria-specifications) that:
 
 - have a [semantic role][] that inherits from the [abstract](https://www.w3.org/TR/wai-aria/#abstract_roles) `input` or `select` role, and
 - does not have a [required context](https://www.w3.org/TR/wai-aria/#scope) role that itself inherits from one of those roles.
 - The `option` role is not part of the list of applicable roles, because it does not meet the definition of a [User interface component](https://www.w3.org/TR/WCAG21/#dfn-user-interface-components). This means [WCAG 2.1](https://www.w3.org/TR/WCAG21/) does not require it to have an [accessible name](#accessible-name).
 
-**Note**: This rule is a partial check for WCAG 2.1 success criterion 2.4.6, which applies to all labels. "Label" is used in its general sense and includes text or other components with a text alternative that is presented to a user to identify a component within Web content.
+**Note:** This rule is a partial check for WCAG 2.1 success criterion 2.4.6, which applies to all labels. "Label" is used in its general sense and includes text or other components with a text alternative that is presented to a user to identify a component within Web content.
 
 ## Expectation
 
 Each target element describes the purpose of the associated form field element.
 
-**Note**: Labels do not need to be lengthy. A word, or even a single character, may suffice.
+**Note:** Labels do not need to be lengthy. A word, or even a single character, may suffice.
 
 ## Assumptions
 

--- a/_rules/heading-accessible-name-ffd0e9.md
+++ b/_rules/heading-accessible-name-ffd0e9.md
@@ -39,7 +39,7 @@ _There are currently no assumptions._
 
 Some assistive technologies may hide headings with empty [accessible name][] from the users. This depends both on the user agent and how the [accessible name][] was computed (the [accessible name and description computation][] is not clear concerning which characters should be trimmed) and of the assistive technology itself. Hence, there are cases where the outcome of this rule is _failed_, but users of certain assistive technology and browser combinations will not experience an issue.
 
-**Note**: Completely empty headings (`<h1></h1>`) seem to be consistently ignored by assistive technologies. However, they fail [Technique H42: Using h1-h6 to identify headings][tech h42] (by using heading markup for content which is not heading). Moreover, they may be rendered on screen (by breaking flow content, or because of custom styling), thus causing concerns for sighted users. Therefore, this rule also fails on these.
+**Note:** Completely empty headings (`<h1></h1>`) seem to be consistently ignored by assistive technologies. However, they fail [Technique H42: Using h1-h6 to identify headings][tech h42] (by using heading markup for content which is not heading). Moreover, they may be rendered on screen (by breaking flow content, or because of custom styling), thus causing concerns for sighted users. Therefore, this rule also fails on these.
 
 ## Background
 

--- a/_rules/heading-descriptive-b49b2e.md
+++ b/_rules/heading-descriptive-b49b2e.md
@@ -24,13 +24,13 @@ acknowledgements:
 
 This rule applies to any element with the [semantic role][] of heading that is either [visible][] or [included in the accessibility tree][].
 
-**Note**: This rule only applies to elements with the [semantic role][] of heading. Thus, it is a partial check for WCAG 2.0 success criterion 2.4.6, which applies to all headings. "Heading" is used in its general sense and includes headlines and other ways to add a heading to different types of content. This includes elements that are not marked up as headings in the code, but still act visually as headings, e.g. by larger and/or bolder text.
+**Note:** This rule only applies to elements with the [semantic role][] of heading. Thus, it is a partial check for WCAG 2.0 success criterion 2.4.6, which applies to all headings. "Heading" is used in its general sense and includes headlines and other ways to add a heading to different types of content. This includes elements that are not marked up as headings in the code, but still act visually as headings, e.g. by larger and/or bolder text.
 
 ## Expectation
 
 Each target element describes the topic or purpose of its [section of the content][].
 
-**Note**: Headings do not need to be lengthy. A word, or even a single character, may suffice.
+**Note:** Headings do not need to be lengthy. A word, or even a single character, may suffice.
 
 ## Assumptions
 

--- a/_rules/html-page-title-2779a5.md
+++ b/_rules/html-page-title-2779a5.md
@@ -29,15 +29,15 @@ htmlHintIgnore:
 
 The root element of the [web page](https://www.w3.org/TR/WCAG21/#dfn-web-page-s), if it is an `html` element.
 
-**Note**: Documents embedded into other documents, such as through `iframe` or `object` elements are not applicable and do not require page titles, because they are not web pages according to the definition in WCAG.
+**Note:** Documents embedded into other documents, such as through `iframe` or `object` elements are not applicable and do not require page titles, because they are not web pages according to the definition in WCAG.
 
 ## Expectation 1
 
 Each target element has at least one [descendant](https://dom.spec.whatwg.org/#concept-tree-descendant) that is an HTML `title` element.
 
-**Note**: The `title` element exists in other namespaces such as SVG. These are not HTML `title` elements and should be ignored for this rule.
+**Note:** The `title` element exists in other namespaces such as SVG. These are not HTML `title` elements and should be ignored for this rule.
 
-**Note**: The [HTML 5.2 specification](https://www.w3.org/TR/html52/document-metadata.html#the-title-element) requires that a document only has one `title` element, and that it is a child of the `head` element of a document. However, HTML 5.2 also describes what should happen in case of multiple titles, and titles outside the `head` element. Because of this, neither of these validation issues causes a conformance problem for WCAG.
+**Note:** The [HTML 5.2 specification](https://www.w3.org/TR/html52/document-metadata.html#the-title-element) requires that a document only has one `title` element, and that it is a child of the `head` element of a document. However, HTML 5.2 also describes what should happen in case of multiple titles, and titles outside the `head` element. Because of this, neither of these validation issues causes a conformance problem for WCAG.
 
 ## Expectation 2
 

--- a/_rules/html-page-title-descriptive-c4a8a4.md
+++ b/_rules/html-page-title-descriptive-c4a8a4.md
@@ -29,9 +29,9 @@ This rule applies to the first HTML `title` element that
 - is a [descendant](https://dom.spec.whatwg.org/#concept-tree-descendant) of the `html` element of a [web page](https://www.w3.org/TR/WCAG21/#dfn-web-page-s), and
 - contains [children](https://dom.spec.whatwg.org/#concept-tree-child) that are [text nodes](https://dom.spec.whatwg.org/#text) that are not only [whitespace](#whitespace).
 
-**Note**: The `title` elements of embedded documents, such as those in `iframe` or `object` elements, are not applicable because those are not web pages according to the definition in WCAG.
+**Note:** The `title` elements of embedded documents, such as those in `iframe` or `object` elements, are not applicable because those are not web pages according to the definition in WCAG.
 
-**Note**: The [HTML 5.2 specification](https://www.w3.org/TR/html52/document-metadata.html#the-title-element) requires that a document only has one `title` element, and that it is a child of the `head` element of a document. However, HTML 5.2 also describes what should happen in case of multiple titles, and titles outside the `head` element. Because of this, neither of these validation issues causes a conformance problem for WCAG.
+**Note:** The [HTML 5.2 specification](https://www.w3.org/TR/html52/document-metadata.html#the-title-element) requires that a document only has one `title` element, and that it is a child of the `head` element of a document. However, HTML 5.2 also describes what should happen in case of multiple titles, and titles outside the `head` element. Because of this, neither of these validation issues causes a conformance problem for WCAG.
 
 ## Expectation
 

--- a/_rules/iframe-accessible-name-cae760.md
+++ b/_rules/iframe-accessible-name-cae760.md
@@ -28,7 +28,7 @@ The rule applies to `iframe` elements that are [included in the accessibility tr
 
 Each target element has an [accessible name][] that is not empty (`""`).
 
-**Note**: Testing that the [accessible name][] is descriptive is not part of this rule and must be tested separately.
+**Note:** Testing that the [accessible name][] is descriptive is not part of this rule and must be tested separately.
 
 ## Assumptions
 

--- a/_rules/image-accessible-name-23a2a8.md
+++ b/_rules/image-accessible-name-23a2a8.md
@@ -31,7 +31,7 @@ The rule applies to HTML `img` elements or any HTML element with the [semantic r
 
 Each target element has an [accessible name][] that is not empty (`""`), or is [marked as decorative][].
 
-**Note**: Testing that the [accessible name][] is descriptive is not part of this rule and must be tested separately.
+**Note:** Testing that the [accessible name][] is descriptive is not part of this rule and must be tested separately.
 
 ## Assumptions
 

--- a/_rules/image-button-accessible-name-59796f.md
+++ b/_rules/image-button-accessible-name-59796f.md
@@ -37,7 +37,7 @@ The rule applies to any HTML `input` element with a `type` attribute in the [`Im
 
 Each target element has an [accessible name][] that is not empty (`""`).
 
-**Note**: Testing that the [accessible name][] is descriptive is not part of this rule and must be tested separately.
+**Note:** Testing that the [accessible name][] is descriptive is not part of this rule and must be tested separately.
 
 ## Assumptions
 

--- a/_rules/link-accessible-name-c487ae.md
+++ b/_rules/link-accessible-name-c487ae.md
@@ -41,7 +41,7 @@ The rule applies to any HTML element with the [semantic role](#semantic-role) of
 
 Each target element has an [accessible name][] that is not empty (`""`).
 
-**Note**: Testing that the [accessible name][] is descriptive is not part of this rule and must be tested separately.
+**Note:** Testing that the [accessible name][] is descriptive is not part of this rule and must be tested separately.
 
 ## Assumptions
 

--- a/_rules/links-identical-name-equivalent-purpose-b20e66.md
+++ b/_rules/links-identical-name-equivalent-purpose-b20e66.md
@@ -305,7 +305,7 @@ These `a` and `area` elements have no `href` attribute.
 
 These links have different [accessible names][accessible name]. The rule only applies to identical [accessible names][accessible name], not to identical link destinations.
 
-**Note**: It is a best practice for [Success Criterion 2.4.9: Link Purpose (Link Only)](https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-link-only.html) that identical links have identical [accessible names][accessible name]. This is however not a requirement.
+**Note:** It is a best practice for [Success Criterion 2.4.9: Link Purpose (Link Only)](https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-link-only.html) that identical links have identical [accessible names][accessible name]. This is however not a requirement.
 
 ```html
 <a href="/test-assets/links-with-identical-names-serve-equivalent-purpose-b20e66/about/contact.html">Reach out</a>

--- a/_rules/meta-refresh-no-delay-bc659a.md
+++ b/_rules/meta-refresh-no-delay-bc659a.md
@@ -40,7 +40,7 @@ The rule applies to the first [valid](https://html.spec.whatwg.org/#attr-meta-ht
 
 The `time` of the `content` attribute is 0 or greater than 72000 (20 hours).
 
-**Note**: See [Refresh state (`http-equiv="refresh"`)](https://html.spec.whatwg.org/#attr-meta-http-equiv-refresh) for a precise description on how to determine the `time`.
+**Note:** See [Refresh state (`http-equiv="refresh"`)](https://html.spec.whatwg.org/#attr-meta-http-equiv-refresh) for a precise description on how to determine the `time`.
 
 ## Assumptions
 

--- a/_rules/no-auto-play-audio-80f0bf.md
+++ b/_rules/no-auto-play-audio-80f0bf.md
@@ -31,7 +31,7 @@ This rule applies to any `audio` or `video` element that has:
 - both `paused` and `muted` attributes equal to false, and
 - either a `src` attribute or a child `source` element that references content with a duration of more than 3 seconds that contains audio.
 
-**Note**:
+**Note:**
 
 The default value of both `paused` and `muted` attributes is `false`.
 

--- a/_rules/text-contrast-afw4f7.md
+++ b/_rules/text-contrast-afw4f7.md
@@ -38,15 +38,15 @@ Any [visible][] character in a [text node][] that is a [child](https://dom.spec.
 - is used in the [accessible name](#accessible-name) of a [widget](https://www.w3.org/TR/wai-aria-1.1/#widget) that is [disabled][]; or
 - has a [semantic role](#semantic-role) of [group](https://www.w3.org/TR/wai-aria-1.1/#group) and is [disabled][].
 
-**Note**: When the [foreground color](#foreground-colors-of-text) is the same as the [background color](#background-colors-of-text), this rule deems the character not [visible][], so it does not need to be tested for contrast.
+**Note:** When the [foreground color](#foreground-colors-of-text) is the same as the [background color](#background-colors-of-text), this rule deems the character not [visible][], so it does not need to be tested for contrast.
 
 ## Expectation
 
 For each test target, the [highest possible contrast](#highest-possible-contrast) between the [foreground colors](#foreground-colors-of-text) and [background colors](#background-colors-of-text) is at least 4.5:1 or 3.0:1 for [larger scale text](#large-scale-text), except if the test target is part of a [text node][] that is [purely decorative][], or does not express anything in [human language](https://www.w3.org/TR/WCAG21/#dfn-human-language-s).
 
-**Note**: Passing this rule does not mean that the text has sufficient color contrast. If all background pixels have a low contrast with all foreground pixels, the success criterion is guaranteed to not be satisfied. When some pixels have sufficient contrast, and others do not, legibility should be considered. There is no clear method for determining legibility, which is why this is out of scope for this rule.
+**Note:** Passing this rule does not mean that the text has sufficient color contrast. If all background pixels have a low contrast with all foreground pixels, the success criterion is guaranteed to not be satisfied. When some pixels have sufficient contrast, and others do not, legibility should be considered. There is no clear method for determining legibility, which is why this is out of scope for this rule.
 
-**Note**: When the text color or background color is not specified in the web page, colors from other [origins](https://www.w3.org/TR/css3-cascade/#cascading-origins) will be used. Testers must ensure colors are not effected by styles from a [user origin](https://www.w3.org/TR/css3-cascade/#cascade-origin-user). Contrast issues cause by specifying the text color but not the background or vise versa, must be tested separately from this rule.
+**Note:** When the text color or background color is not specified in the web page, colors from other [origins](https://www.w3.org/TR/css3-cascade/#cascading-origins) will be used. Testers must ensure colors are not effected by styles from a [user origin](https://www.w3.org/TR/css3-cascade/#cascade-origin-user). Contrast issues cause by specifying the text color but not the background or vise versa, must be tested separately from this rule.
 
 ## Assumptions
 
@@ -139,7 +139,7 @@ This 14pt bold black text has a contrast ratio of 3.6:1 on the gray background.
 
 The first `p` element is has a contrast ratio of 21:1 (default black on white). The second `p` element contains Helvetica text which is decorative, because it does not convey information or provides functionality; its purpose is to show the aesthetic of the Helvetica font.
 
-**Note**: Because this is non-text content, [success criterion 1.4.11 Non-text Contrast](https://www.w3.org/TR/WCAG21/#non-text-contrast) requires font example to have a color contrast of 3:1.
+**Note:** Because this is non-text content, [success criterion 1.4.11 Non-text Contrast](https://www.w3.org/TR/WCAG21/#non-text-contrast) requires font example to have a color contrast of 3:1.
 
 ```html
 <p style="color: #333; background: #FFF;">

--- a/_rules/video-captions-f51b46.md
+++ b/_rules/video-captions-f51b46.md
@@ -24,7 +24,7 @@ The rule applies to every [non-streaming](#non-streaming-media-element) `video` 
 
 For each test target, audio information that is not conveyed visually in the video, is available through [captions](https://www.w3.org/TR/WCAG21/#dfn-captions).
 
-**Note**: Captions can be either embedded in the video file itself or can be made available trough a separate track.
+**Note:** Captions can be either embedded in the video file itself or can be made available trough a separate track.
 
 ## Assumptions
 

--- a/_rules/video-only-transcript-ee13b5.md
+++ b/_rules/video-only-transcript-ee13b5.md
@@ -28,7 +28,7 @@ The rule applies to any [non-streaming](#non-streaming-media-element) `video` el
 
 The visual information of each test target is available through a text transcript that is available either on the page or through a link. The text transcript needs to be [visible][] and [included in the accessibility tree][].
 
-**Note**: A "text transcript" in the context of this rule is defined in WCAG 2 as an [alternative for time based media](https://www.w3.org/TR/WCAG21/#dfn-alternative-for-time-based-media).
+**Note:** A "text transcript" in the context of this rule is defined in WCAG 2 as an [alternative for time based media](https://www.w3.org/TR/WCAG21/#dfn-alternative-for-time-based-media).
 
 ## Assumptions
 

--- a/_rules/video-transcript-1a02b0.md
+++ b/_rules/video-transcript-1a02b0.md
@@ -33,7 +33,7 @@ The rule applies to every [non-streaming](#non-streaming-media-element) `video` 
 
 A text transcript containing all the visual and auditory information of the test target is available, either on the page or available through a link.
 
-**Note**: A "text transcript" in the context of this rule is defined in WCAG 2 as an [alternative for time based media](https://www.w3.org/TR/WCAG21/#dfn-alternative-for-time-based-media).
+**Note:** A "text transcript" in the context of this rule is defined in WCAG 2 as an [alternative for time based media](https://www.w3.org/TR/WCAG21/#dfn-alternative-for-time-based-media).
 
 ## Assumptions
 

--- a/_rules/visible-label-in-accessible-name-2ee8b8.md
+++ b/_rules/visible-label-in-accessible-name-2ee8b8.md
@@ -28,13 +28,13 @@ This rule applies to any element that has:
 - [visible text content](#visible-text-content), and
 - an `aria-label` or `aria-labelledby` attribute.
 
-**Note**: [widget roles](https://www.w3.org/TR/wai-aria-1.1/#widget_roles) that [supports name from content](https://www.w3.org/TR/wai-aria-1.1/#namefromcontent) are: `button`, `checkbox`, `gridcell`, `link`, `menuitem`, `menuitemcheckbox`, `menuitemradio`, `option`, `radio`, `searchbox`, `switch`, `tab`, `treeitem`.
+**Note:** [widget roles](https://www.w3.org/TR/wai-aria-1.1/#widget_roles) that [supports name from content](https://www.w3.org/TR/wai-aria-1.1/#namefromcontent) are: `button`, `checkbox`, `gridcell`, `link`, `menuitem`, `menuitemcheckbox`, `menuitemradio`, `option`, `radio`, `searchbox`, `switch`, `tab`, `treeitem`.
 
 ## Expectation
 
 The complete [visible text content](#visible-text-content) of the target element either matches or is contained within its [accessible name][].
 
-**Note**: Leading and trailing [whitespace](#whitespace) and difference in case sensitivity should be ignored.
+**Note:** Leading and trailing [whitespace](#whitespace) and difference in case sensitivity should be ignored.
 
 ## Assumptions
 


### PR DESCRIPTION
When writing notes, the colon at the end of "Note:" was sometimes in bold and sometimes not. This put it in bold all over the place, which was the most frequent case.

Closes issue(s):

- Closes #1113 

Need for Final Call:
This will not require a Final Call (editorial change)

---

## Pull Request Etiquette

### **When creating PR:**

- Make sure you requesting to **pull a branch** (right side) to the `develop` branch (left side).

### **After creating PR:**

- Add yourself (and co-authors) as "Assignees" for PR.
- Add label to indicate if it's a `Rule`, `Definition` or `Chore`.
- Close the issue that the PR resolves (and make sure the issue is referenced in the top of this comment)
- Optionally request feedback from anyone in particular by assigning them as "Reviewers".

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Final Call period. In case of disagreement, the longer period wins.
