### PR TITLE
button-acc-name: update link in background section

### DIFF
--- a/_rules/button-accessible-name-97a4e1.md
+++ b/_rules/button-accessible-name-97a4e1.md
@@ -43,7 +43,7 @@ There are no major accessibility support issues known for this rule.
 
 ## Background
 
-- [HTML Accessibility API Mappings 1.0 (working draft)](https://www.w3.org/TR/html-aam/)
+- [HTML Accessibility API Mappings 1.0 (working draft), 5.2 `input type="button"`, `input type="submit"` and `input type="reset"`](https://www.w3.org/TR/html-aam/#input-type-button-input-type-submit-and-input-type-reset)
 - [Understanding Success Criterion 4.1.2: Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value)
 - [ARIA14: Using aria-label to provide an invisible label where a visible label cannot be used](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA14)
 - [ARIA16: Using aria-labelledby to provide a name for user interface controls](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA16)


### PR DESCRIPTION
Closes part of: https://github.com/w3c/wcag-act/issues/427, specifically:

>  Update link to HTML Core Mappings to button section. act-rules/act-rules.github.io#1063


Need for Final Call: none