### PR TITLE
Add note to explain why disabled fields are applicable (e086e5)

### DIFF
--- a/_rules/form-control-accessible-name-e086e5.md
+++ b/_rules/form-control-accessible-name-e086e5.md
@@ -41,7 +41,8 @@ _There are currently no assumptions_
 
 ## Accessibility Support
 
-Certain assistive technologies can be set up to ignore the title attribute, which means that to some users the title attribute will not act as an [accessible name][].
+- Certain assistive technologies can be set up to ignore the title attribute, which means that to some users the title attribute will not act as an [accessible name][].
+- Several assistive technologies have a functionality to list all form fields on a page, including the `disabled` ones. Therefore this rule is still applicable to `disabled` form fields. If an assistive technology consistently ignores `disabled` form fields in all its interactions, then it is possible to have a `disabled` form field with no accessible name without creating accessibility issues for the user.
 
 ## Background
 


### PR DESCRIPTION
Add an Accessibility Support note to explain why the rule is applicable to disabled form fields (following decision of ACT CG call on 27/02/2020).

Closes issue(s):

- closes #1164 

Need for Final Call:
This will not require a Final Call (change to Accessibility Support)

---

## Pull Request Etiquette

### **When creating PR:**

- [x] Make sure you're requesting to **pull a branch** (right side) to the `develop` branch (left side).

### **After creating PR:**

- [x] Add yourself (and co-authors) as "Assignees" for PR.
- [x] Add label to indicate if it's a `Rule`, `Definition` or `Chore`.
- [x] Close the issue that the PR resolves (and make sure the issue is referenced in the top of this comment)
- [x] Optionally request feedback from anyone in particular by assigning them as "Reviewers".

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Final Call period. In case of disagreement, the longer period wins.
