### PR TITLE
Remove Kasper as author of "Text has minimum contrast" (afw4f7)

### DIFF
--- a/_rules/text-contrast-afw4f7.md
+++ b/_rules/text-contrast-afw4f7.md
@@ -26,7 +26,6 @@ input_aspects:
 acknowledgements:
   authors:
     - Brian Bors
-    - Kasper Isager
     - Wilco Fiers
 ---
 


### PR DESCRIPTION
While I do appreciate the acknowledgement, I'd prefer not being listed as an author as I don't feel that I've contributed enough to consider myself a co-author. Thanks! 🙏 