### PR TITLE
Update note on testing if accessible name is descriptive (97a4e1 / 7d6734 / e086e5 / cae760 / 23a2a8 / 59796f / c487ae) 

### DIFF
--- a/_rules/button-accessible-name-97a4e1.md
+++ b/_rules/button-accessible-name-97a4e1.md
@@ -31,7 +31,7 @@ Each target element has an [accessible name][] that is not empty (`""`).
 
 **Note:** `input` elements of type `submit` and `reset` can get their [accessible name][] from a [default text](https://www.w3.org/TR/html-aam/#input-type-button-input-type-submit-and-input-type-reset), as well as from a `value` or other attribute.
 
-**Note:** Testing that the [accessible name][] is descriptive is not part of this rule and must be tested separately.
+**Note:** Testing that the [accessible name][] describes the purpose of the element is not part of this rule and must be tested separately.
 
 ## Assumptions
 

--- a/_rules/explicit-SVG-image-has-name-7d6734.md
+++ b/_rules/explicit-SVG-image-has-name-7d6734.md
@@ -28,7 +28,7 @@ The rule applies to any element in the [SVG](https://www.w3.org/2000/svg) namesp
 
 Each target element has an [accessible name][] that is not empty.
 
-**Note:** Testing that the [accessible name][] is descriptive is not part of this rule and must be tested separately.
+**Note:** Testing that the [accessible name][] describes the purpose of the element is not part of this rule and must be tested separately.
 
 ## Assumptions
 

--- a/_rules/form-control-accessible-name-e086e5.md
+++ b/_rules/form-control-accessible-name-e086e5.md
@@ -33,7 +33,7 @@ This rule applies to any element that is [included in the accessibility tree](#i
 
 Each target element has an [accessible name][] that is not empty (`""`).
 
-**Note:** Testing that the [accessible name][] is descriptive is not part of this rule and must be tested separately.
+**Note:** Testing that the [accessible name][] describes the purpose of the element is not part of this rule and must be tested separately.
 
 ## Assumptions
 

--- a/_rules/iframe-accessible-name-cae760.md
+++ b/_rules/iframe-accessible-name-cae760.md
@@ -29,7 +29,7 @@ The rule applies to `iframe` elements that are [included in the accessibility tr
 
 Each target element has an [accessible name][] that is not empty (`""`).
 
-**Note:** Testing that the [accessible name][] is descriptive is not part of this rule and must be tested separately.
+**Note:** Testing that the [accessible name][] describes the purpose of the element is not part of this rule and must be tested separately.
 
 ## Assumptions
 

--- a/_rules/image-accessible-name-23a2a8.md
+++ b/_rules/image-accessible-name-23a2a8.md
@@ -41,7 +41,7 @@ The rule applies to HTML `img` elements or any HTML element with the [semantic r
 
 Each target element has an [accessible name][] that is not empty (`""`), or is [marked as decorative][].
 
-**Note:** Testing that the [accessible name][] is descriptive is not part of this rule and must be tested separately.
+**Note:** Testing that the [accessible name][] describes the purpose of the element is not part of this rule and must be tested separately.
 
 ## Assumptions
 

--- a/_rules/image-button-accessible-name-59796f.md
+++ b/_rules/image-button-accessible-name-59796f.md
@@ -47,7 +47,7 @@ The rule applies to any HTML `input` element with a `type` attribute in the [`Im
 
 Each target element has an [accessible name][] that is not empty (`""`).
 
-**Note:** Testing that the [accessible name][] is descriptive is not part of this rule and must be tested separately.
+**Note:** Testing that the [accessible name][] describes the purpose of the element is not part of this rule and must be tested separately.
 
 ## Assumptions
 

--- a/_rules/link-accessible-name-c487ae.md
+++ b/_rules/link-accessible-name-c487ae.md
@@ -46,7 +46,7 @@ The rule applies to any HTML element with the [semantic role](#semantic-role) of
 
 Each target element has an [accessible name][] that is not empty (`""`).
 
-**Note:** Testing that the [accessible name][] is descriptive is not part of this rule and must be tested separately.
+**Note:** Testing that the [accessible name][] describes the purpose of the element is not part of this rule and must be tested separately.
 
 ## Assumptions
 


### PR DESCRIPTION
Update the note that testing if accessible name is descriptive is not part of the rule.

Closes issue(s):

- closes #1185

Need for Final Call:
This will not require a Final Call (updating a non-normative note)

---

## Pull Request Etiquette

### **When creating PR:**

- [X] Make sure you're requesting to **pull a branch** (right side) to the `develop` branch (left side).

### **After creating PR:**

- [X] Add yourself (and co-authors) as "Assignees" for PR.
- [X] Add label to indicate if it's a `Rule`, `Definition` or `Chore`.
- [x] Close the issue that the PR resolves (and make sure the issue is referenced in the top of this comment)
- [X] Optionally request feedback from anyone in particular by assigning them as "Reviewers".

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Final Call period. In case of disagreement, the longer period wins.
