### PR TITLE
test: allow to specify outdated links to ignore via frontmatter

### DIFF
--- a/__tests__/link-is-outdated.js
+++ b/__tests__/link-is-outdated.js
@@ -27,11 +27,12 @@ const badLinksAndRecommendations = {
  * Validate `Rules` and `Pages` markdown files
  */
 describe('Validate links are not outdated', () => {
-	describeRule('Rules', ({ markdownAST }) => validateIfLinksAreOutdated(markdownAST))
-	describePage('Pages', ({ markdownAST }) => validateIfLinksAreOutdated(markdownAST))
+	describeRule('Rules', validateIfLinksAreOutdated)
+	describePage('Pages', validateIfLinksAreOutdated)
 })
 
-function validateIfLinksAreOutdated(markdownAST) {
+function validateIfLinksAreOutdated({ markdownAST, frontmatter }) {
+	const { oudatedLinksIgnore = [] } = frontmatter
 	/**
 	 * get all links
 	 * -> eg: [Alpha](https://....)
@@ -53,7 +54,12 @@ function validateIfLinksAreOutdated(markdownAST) {
 	}
 
 	test.each(links)('%s', link => {
-		const badLink = Object.keys(badLinksAndRecommendations).find(badLink => link.includes(badLink))
-		expect(!!badLink, badLinksAndRecommendations[badLink]).toBe(false)
+		let badLink = !!Object.keys(badLinksAndRecommendations).find(badLink => link.includes(badLink))
+		// if blacklisted outdated link but in ignore list, then reset to false
+		if (badLink && !!oudatedLinksIgnore.find(ignoreLink => link.includes(ignoreLink))) {
+			badLink = false
+		}
+
+		expect(badLink, badLinksAndRecommendations[badLink]).toBe(false)
 	})
 }


### PR DESCRIPTION
@Jym77 reached out to me, asking if there is a way to allow for the tests to ignore some outdated URL's, as it was necessary in this PR - https://github.com/act-rules/act-rules.github.io/pull/1159/files#diff-2519a9e676dbe7354e8748d37531e252R20

Hence, added the ability to specify an ignored list of URL's in the frontmatter  where necessary.

Eg: Adding the below helps the test to ignore such URL's
```
---
oudatedLinksIgnore:
  # ignore below links from `link-is-outdated` test
  - '://www.w3.org/TR/html52'
  - 'CAN BE ACTUAL FULL URL TOO'
---
```

Closes issue(s):
- NA

Need for Final Call:
- NA
