### PR TITLE
color-contrast: script issue in passed example 10

### DIFF
--- a/_rules/text-contrast-afw4f7.md
+++ b/_rules/text-contrast-afw4f7.md
@@ -185,7 +185,7 @@ This dark gray text has a contrast ratio of 12.6:1 on the white background in a 
 <p style="color: #CCC; background: #fff;" id="p"></p>
 <script>
 	const shadowRoot = document.getElementById('p').attachShadow({ mode: 'open' })
-	shadowRoot.textContent = '<span style="color: #333;">Some text in English</span>'
+	shadowRoot.innerHTML = '<span style="color: #333;">Some text in English</span>'
 </script>
 ```
 


### PR DESCRIPTION
Passed example 10 should use `.innerHTML` and not `.textContent`, otherwise the adjusted color contrast isn't applied correctly and the example fails.

Need for Final Call: 1 week