### PR TITLE
test: ignore `aria-*` keys ending with punctuation

### DIFF
--- a/__tests__/spelling.js
+++ b/__tests__/spelling.js
@@ -129,17 +129,14 @@ function getSpellIgnored() {
 		}
 	})
 
-	const ariaKeys = Array.from(ariaQuery.aria.keys())
-	const ignoreAria = [
-		...ariaKeys,
-		/**
-		 * `retext-spell` parses word nodes sometimes with an ending punctuation when the word is not a part of the dictionary.
-		 * See Issue: https://github.com/syntax-tree/nlcst/issues/4
-		 *
-		 * Below, we all aria keys ending with punctuation (.), to the ignore list
-		 */
-		...ariaKeys.map(key => `${key}.`),
-	]
+	/**
+	 * `retext-spell` by default checks spelling of individual words before ensuring validity of a composite word.
+	 * Eg: `aria-valuenow` is first checked for spelling for `aria` then `valuenow`, and if both of those fail, then validity of the entire word is checked.
+	 *
+	 * Below we are setting individual aria keys as valid (ignore list), thereby bypassing a composite word check.
+	 * This is to circumvent isses when `aria-*` attribues are followed by other characters eg: punctuation
+	 */
+	const ignoreAria = ['aria', ...Array.from(ariaQuery.aria.keys())].map(key => key.replace(/aria-/, ''))
 	const ignoreDom = Array.from(ariaQuery.dom.keys())
 	const ignoreRoles = Array.from(ariaQuery.roles.keys())
 

--- a/__tests__/spelling.js
+++ b/__tests__/spelling.js
@@ -129,9 +129,19 @@ function getSpellIgnored() {
 		}
 	})
 
-	const ignoreAria = ariaQuery.aria.keys()
-	const ignoreDom = ariaQuery.dom.keys()
-	const ignoreRoles = ariaQuery.roles.keys()
+	const ariaKeys = Array.from(ariaQuery.aria.keys())
+	const ignoreAria = [
+		...ariaKeys,
+		/**
+		 * `retext-spell` parses word nodes sometimes with an ending punctuation when the word is not a part of the dictionary.
+		 * See Issue: https://github.com/syntax-tree/nlcst/issues/4
+		 *
+		 * Below, we all aria keys ending with punctuation (.), to the ignore list
+		 */
+		...ariaKeys.map(key => `${key}.`),
+	]
+	const ignoreDom = Array.from(ariaQuery.dom.keys())
+	const ignoreRoles = Array.from(ariaQuery.roles.keys())
 
 	return [...ignoreConfigured, ...ignoreExtra, ...ignoreAria, ...ignoreDom, ...ignoreRoles]
 }


### PR DESCRIPTION
Tests fail when an `aria-*` key ends with punctuation. See - https://github.com/act-rules/act-rules.github.io/pull/1266/checks?check_run_id=567292841

This is because `retext-spell` parses `WordNodes` ending with punctuations wrongly. Reading further is became apparent that this gets complicated very quickly with natural language processing and esp., with words like `e.g.`, `i.e.`, `Mrs. ` etc.,

So `retext-spell` has taken the easier approach of taking punctuations into consideration when a given work is not a part of the dictionary.

Given this usage case, it made sense to simple add all `aria-*` keys with a punctuation of `.` at the end to the ignore list.

The solution is not the cleanest, but neither were other options, like:
1) Remove all punctuations from a given text before checking spelling.
2) Use markdown syntax tree to build a new text node (large task for a simple gain). 

Closes Issue:
- NA

> Note: No need for final call, and will be merged after one approval