### PR TITLE
test: ignore backticks from link reference and definition identifiers

### DIFF
--- a/__tests__/link-reference-has-definition.js
+++ b/__tests__/link-reference-has-definition.js
@@ -22,14 +22,14 @@ describe(`Validate link references`, () => {
 
 function validateLinkReferences(markdownAST) {
 	const linkReferences = uniqueArray(
-		getMarkdownAstNodesOfType(markdownAST, 'linkReference').map(({ identifier }) => identifier)
+		getMarkdownAstNodesOfType(markdownAST, 'linkReference').map(({ identifier }) => identifier.replace(/`/g, ''))
 	)
 	if (!linkReferences || !linkReferences.length) {
 		return
 	}
 
 	const definitions = uniqueArray(
-		getMarkdownAstNodesOfType(markdownAST, 'definition').map(({ identifier }) => identifier)
+		getMarkdownAstNodesOfType(markdownAST, 'definition').map(({ identifier }) => identifier.replace(/`/g, ''))
 	)
 
 	test.each(linkReferences)('%s', linkRef => {


### PR DESCRIPTION
@carlosapaduarte noticed me that a test for link reference to a definition was failing like so - https://github.com/act-rules/act-rules.github.io/pull/1010/checks?check_run_id=566929847

This was because the identifier returned by the markdown syntax tree includes the back ticks as a part of the key of the link reference, and there was no definition key with a back tick.

It makes sense to exclude backticks for comparison of keys between link references and their definitions.

> Note: No final call & can be merged with 1 approval.