### PR TITLE
Fix expectation to exclude self-reference

### DIFF
--- a/_rules/table-headers-attribute-refer-to-data-cells-a25f45.md
+++ b/_rules/table-headers-attribute-refer-to-data-cells-a25f45.md
@@ -30,7 +30,9 @@ This rule applies to any `headers` attribute specified on a [`cell`][] within a 
 
 ## Expectation
 
-Each target attribute is [a set of space separated IDs][], each of which is the ID of an element, that is a [`cell`][] of the same [`table`][] as the target element.
+Each target attribute is [a set of space separated IDs][], each of which is the ID of an element, that is a [`cell`][] of the same [`table`][] as the target element different from the target.
+
+**Note:** `headers` attribute referencing to the cell itself are ignored when [assigning header cells (step 6)](https://html.spec.whatwg.org/multipage/tables.html#algorithm-for-assigning-header-cells).
 
 ## Assumptions
 
@@ -217,7 +219,7 @@ The `td` element has a `headers` attribute referring to an ID that does not exis
 
 #### Failed Example 2
 
-The `td` element has a `headers` attribute referring to it's own ID.
+The `td` element has a `headers` attribute referring to its own ID.
 
 ```html
 <table>

--- a/_rules/table-headers-attribute-refer-to-data-cells-a25f45.md
+++ b/_rules/table-headers-attribute-refer-to-data-cells-a25f45.md
@@ -28,9 +28,13 @@ acknowledgments:
 
 This rule applies to any `headers` attribute specified on a [`cell`][] within a [`table`][] element, where the [`table`][] element is [visible][] and [included in the accessibility tree][].
 
-## Expectation
+## Expectation 1
 
-Each target attribute is [a set of space separated IDs][], each of which is the ID of an element, that is a [`cell`][] of the same [`table`][] as the target element different from the target.
+Each target attribute is [a set of space separated IDs][], each of which is the ID of an element, that is a [`cell`][] of the same [`table`][].
+
+## Expectation 2
+
+Each target attribute is [a set of space separated IDs][], none of which is the ID of the element on which the test target is specified.
 
 **Note:** `headers` attribute referencing to the cell itself are ignored when [assigning header cells (step 6)](https://html.spec.whatwg.org/multipage/tables.html#algorithm-for-assigning-header-cells).
 

--- a/_rules/table-headers-attribute-refer-to-data-cells-a25f45.md
+++ b/_rules/table-headers-attribute-refer-to-data-cells-a25f45.md
@@ -32,6 +32,8 @@ This rule applies to any `headers` attribute specified on a [`cell`][] within a 
 
 Each target attribute is [a set of space separated IDs][], each of which is the ID of an element, that is a [`cell`][] of the same [`table`][].
 
+**Note:** `headers` attribute referencing elements that are non-existent or not in the table are ignored when [assigning header cells (step 3, first case, point 2)](https://html.spec.whatwg.org/multipage/tables.html#algorithm-for-assigning-header-cells).
+
 ## Expectation 2
 
 Each target attribute is [a set of space separated IDs][], none of which is the ID of the element on which the test target is specified.

--- a/_rules/table-headers-attribute-refer-to-data-cells-a25f45.md
+++ b/_rules/table-headers-attribute-refer-to-data-cells-a25f45.md
@@ -36,7 +36,7 @@ Each target attribute is [a set of space separated IDs][], each of which is the 
 
 Each target attribute is [a set of space separated IDs][], none of which is the ID of the element on which the test target is specified.
 
-**Note:** `headers` attribute referencing to the cell itself are ignored when [assigning header cells (step 6)](https://html.spec.whatwg.org/multipage/tables.html#algorithm-for-assigning-header-cells).
+**Note:** `headers` attribute referencing to the cell itself are ignored when [assigning header cells (step 3, first case, point 2)](https://html.spec.whatwg.org/multipage/tables.html#algorithm-for-assigning-header-cells).
 
 ## Assumptions
 


### PR DESCRIPTION
Exclude the target itself from the valid `headers` IDs.
This follow assignation algorithm removing the principal cell from the list of headers, and makes Failed Example 2 actually fail.

Closes issue(s):

- closes #1261

Need for Final Call:
This will require a 1 week Final Call (small update to expectation)

---

## Pull Request Etiquette

### **When creating PR:**

- [X] Make sure you're requesting to **pull a branch** (right side) to the `develop` branch (left side).

### **After creating PR:**

- [X] Add yourself (and co-authors) as "Assignees" for PR.
- [X] Add label to indicate if it's a `Rule`, `Definition` or `Chore`.
- [X] Close the issue that the PR resolves (and make sure the issue is referenced in the top of this comment)
- [X] Optionally request feedback from anyone in particular by assigning them as "Reviewers".

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Final Call period. In case of disagreement, the longer period wins.
