### PR TITLE
Correcting typos in semantic role definitions

### DIFF
--- a/pages/glossary/hidden-state.md
+++ b/pages/glossary/hidden-state.md
@@ -11,11 +11,12 @@ input_aspects:
 An HTML element's _hidden state_ is "true" if at least one of the following is true for itself or any of its [ancestors][] in the [flat tree][]:
 
 - has a `hidden` attribute; or
-- has a [computed](https://www.w3.org/TR/css-cascade/#computed-value) CSS property `display` of `none`; or
-- has a [computed](https://www.w3.org/TR/css-cascade/#computed-value) CSS property `visibility` of `hidden`.
+- has a [computed][] CSS property `display` of `none`; or
+- has a [computed][] CSS property `visibility` of `hidden`; or
 - has an `aria-hidden` attribute set to `true`
 
 In any other case, the element's _hidden state_ is "false".
 
 [ancestors]: https://dom.spec.whatwg.org/#concept-tree-ancestor 'Definition Ancestor'
+[computed]: https://www.w3.org/TR/css-cascade/#computed-value 'CSS definition of computed value'
 [flat tree]: https://drafts.csswg.org/css-scoping/#flat-tree 'Definition of flat tree'

--- a/pages/glossary/semantic-role.md
+++ b/pages/glossary/semantic-role.md
@@ -13,7 +13,7 @@ Valid semantic roles are defined by standards. For web content and applications 
 
 The _semantic role_ of an element is determined by the first of these cases that applies:
 
-1. **Conflict** If the element has an [explicit role][] which is either `none` or `presentation`, but the element is [included in the accessibility tree][]; or would be [included in the accessibility tree][] when its [hidden state](#hidden-state) is true, then its _semantic role_ is its **[implicit role][]**.
+1. **Conflict** If the element has an [explicit role][] which is either `none` or `presentation`, but the element is [included in the accessibility tree][]; or would be [included in the accessibility tree][] when its [hidden state](#hidden-state) is false, then its _semantic role_ is its **[implicit role][]**.
 2. **Explicit** If the element has an [explicit role][], then its _semantic role_ is its [explicit role][].
 3. **Implicit** The _semantic role_ of the element is its [implicit role][].
 


### PR DESCRIPTION
There was a few typos in the presentation role conflict resolution PR…

Most annoying being the true/false one on the hidden state 😱 

Closes issue(s):

- N/A

Need for Final Call:
This will not require a Final Call (typos and bugfix)

---

## Pull Request Etiquette

### **When creating PR:**

- [X] Make sure you're requesting to **pull a branch** (right side) to the `develop` branch (left side).

### **After creating PR:**

- [X] Add yourself (and co-authors) as "Assignees" for PR.
- [X] Add label to indicate if it's a `Rule`, `Definition` or `Chore`.
- [ ] Close the issue that the PR resolves (and make sure the issue is referenced in the top of this comment)
- [X] Optionally request feedback from anyone in particular by assigning them as "Reviewers".

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Final Call period. In case of disagreement, the longer period wins.
