### PR TITLE
Replace usage of attribute=value in the applicability of "Element with aria-hidden has no focusable content" (6cfa84)

### DIFF
--- a/_rules/aria-hidden-no-focusable-content-6cfa84.md
+++ b/_rules/aria-hidden-no-focusable-content-6cfa84.md
@@ -31,7 +31,7 @@ acknowledgments:
 
 ## Applicability
 
-The rule applies to any element with an `aria-hidden="true"` attribute.
+The rule applies to any element with an `aria-hidden` attribute with a value that is an ASCII case-insensitive match for "true".
 
 **Note:** Using `aria-hidden="false"` on a descendant of an element with `aria-hidden="true"` **does not** expose that element. `aria-hidden="true"` hides itself and all its content from assistive technologies.
 


### PR DESCRIPTION
This rule uses `aria-hidden="true"` in the applicability. 
Replacing it as suggested in https://github.com/act-rules/act-rules.github.io/issues/584#issuecomment-527828361

Need for Final Call:
This will require a 1 week Final Call (rephrasing the applicability)

---

## Pull Request Etiquette

### **When merging a PR:**

- [ ] Close any issue that the PR resolves. This will happen automatically upon merging if the PR was correctly linked to the issue, e.g. by referencing the issue at the top of this comment.

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Final Call period. In case of disagreement, the longer period wins.
