### PR TITLE
chore: update publish github workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: 'master'
       - uses: actions/setup-node@v1
       - run: |
           git config user.name "${{ secrets.USER_NAME }}"


### PR DESCRIPTION
Update publish workflow to run only against `master` branch