### PR TITLE
Rename "form control" to "form field"

### DIFF
--- a/_rules/form-field-non-empty-accessible-name-e086e5.md
+++ b/_rules/form-field-non-empty-accessible-name-e086e5.md
@@ -46,7 +46,7 @@ The list of roles in the applicability is derived by taking all the roles from [
 - have [semantic roles][] that inherit from the [abstract](https://www.w3.org/TR/wai-aria/#abstract_roles) `input` or `select` role, and
 - do not have a [required context](https://www.w3.org/TR/wai-aria/#scope) role that itself inherits from one of those roles.
 
-Note that this rule does not test certain other control-like roles such as `button` and `menuitem`, because these do not in herit from `input` or `select`. These should be tested separately.
+Note that this rule does not test other control-like roles such as `button` and `menuitem`, because these do not inherit from `input` or `select`. These should be tested separately.
 
 This rule does not map to [3.3.2 Labels or Instructions](https://www.w3.org/TR/WCAG21/#labels-or-instructions) as there are sufficient techniques within 3.3.2 that don't need the elements to have an [accessible name][]. For example "[G131: Providing descriptive labels](https://www.w3.org/WAI/WCAG21/Techniques/general/G131)" **AND** "[G162: Positioning labels to maximize predictability of relationships](https://www.w3.org/WAI/WCAG21/Techniques/general/G162)" would be sufficient.
 

--- a/_rules/form-field-non-empty-accessible-name-e086e5.md
+++ b/_rules/form-field-non-empty-accessible-name-e086e5.md
@@ -1,6 +1,6 @@
 ---
 id: e086e5
-name: Form control has non-empty accessible name
+name: Form field has non-empty accessible name
 rule_type: atomic
 description: |
   This rule checks that each form field element has a non-empty accessible name.
@@ -45,6 +45,8 @@ The list of roles in the applicability is derived by taking all the roles from [
 
 - have [semantic roles][] that inherit from the [abstract](https://www.w3.org/TR/wai-aria/#abstract_roles) `input` or `select` role, and
 - do not have a [required context](https://www.w3.org/TR/wai-aria/#scope) role that itself inherits from one of those roles.
+
+Note that this rule does not test certain other control-like roles such as `button` and `menuitem`, because these do not in herit from `input` or `select`. These should be tested separately.
 
 This rule does not map to [3.3.2 Labels or Instructions](https://www.w3.org/TR/WCAG21/#labels-or-instructions) as there are sufficient techniques within 3.3.2 that don't need the elements to have an [accessible name][]. For example "[G131: Providing descriptive labels](https://www.w3.org/WAI/WCAG21/Techniques/general/G131)" **AND** "[G162: Positioning labels to maximize predictability of relationships](https://www.w3.org/WAI/WCAG21/Techniques/general/G162)" would be sufficient.
 
@@ -149,7 +151,7 @@ This `select` element has an empty (`""`) [accessible name][] because the `div` 
 
 #### Failed Example 5
 
-This element with a `textbox` [role][semantic role] has an empty (`""`) [accessible name][]. The parent `label` element does not give it an [accessible name][], this only works for native form controls.
+This element with a `textbox` [role][semantic role] has an empty (`""`) [accessible name][]. The parent `label` element does not give it an [accessible name][], this only works for native form fields.
 
 ```html
 <label>
@@ -160,7 +162,7 @@ This element with a `textbox` [role][semantic role] has an empty (`""`) [accessi
 
 #### Failed Example 6
 
-This element with a `textbox` [role][semantic role] has an empty (`""`) [accessible name][]. The `label` element does not give it an [accessible name][], this only works for native form controls.
+This element with a `textbox` [role][semantic role] has an empty (`""`) [accessible name][]. The `label` element does not give it an [accessible name][], this only works for native form fields.
 
 ```html
 <label for="lastname">first name</label>


### PR DESCRIPTION
In order to clarify that this rule does not apply to buttons, the rule no longer uses the phrase "form control" instead it uses "form field" to make it clear this rule does not apply to buttons.

This change was suggested during a call with the ACT TF

Need for Final Call: 1 week