### PR TITLE
make visible text content definition objective

### DIFF
--- a/_rules/visible-label-in-accessible-name-2ee8b8.md
+++ b/_rules/visible-label-in-accessible-name-2ee8b8.md
@@ -38,7 +38,7 @@ This rule applies to any element that has:
 
 ## Expectation
 
-All [text nodes][] in the [visible text content][] of each target element matches, or is contained within the [accessible name][] of the target element, except for [text nodes][] contains [non-text content][]. Leading and trailing [whitespace][] and difference in case sensitivity should be ignored.
+All [text nodes][] in the [visible text content][] of each target element matches, or is contained within the [accessible name][] of the target element, except for characters used to express [non-text content][]. Leading and trailing [whitespace][] and difference in case sensitivity should be ignored.
 
 ## Assumptions
 
@@ -87,6 +87,20 @@ This button has [visible][] text that does not need to be included in the [acces
 
 ```html
 <button aria-label="close">X</button>
+```
+
+#### Passed Example 5
+
+This `button` element has the text "search" rendered as an hourglass icon by the font. Because the text is rendered as [non-text content][], the text does not need to be included in the [accessible name][].
+
+```html
+<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+<style>
+	button {
+		font-family: 'Material Icons';
+	}
+</style>
+<button aria-label="Find">search</button>
 ```
 
 ### Failed
@@ -161,3 +175,4 @@ This link has no [visible text content][].
 [visible text content]: #visible-text-content 'Definition of Visible text content'
 [whitespace]: #whitespace 'Definition of Whitespace'
 [widget roles]: https://www.w3.org/TR/wai-aria-1.1/#widget_roles 'Definition of Widget role'
+[text nodes]: https://dom.spec.whatwg.org/#text 'DOM text, 2020/08/18'

--- a/_rules/visible-label-in-accessible-name-2ee8b8.md
+++ b/_rules/visible-label-in-accessible-name-2ee8b8.md
@@ -38,7 +38,7 @@ This rule applies to any element that has:
 
 ## Expectation
 
-For each target element, all [text nodes][] in the [visible text content][] either matches or is contained within the [accessible name][] of this target element, except for characters in the [text nodes][] used to express [non-text content][]. Leading and trailing [whitespace][] and difference in case sensitivity should be ignored.
+For each target element, all [text nodes][] in the [visible text content][] either match or are contained within the [accessible name][] of this target element, except for characters in the [text nodes][] used to express [non-text content][]. Leading and trailing [whitespace][] and difference in case sensitivity should be ignored.
 
 ## Assumptions
 

--- a/_rules/visible-label-in-accessible-name-2ee8b8.md
+++ b/_rules/visible-label-in-accessible-name-2ee8b8.md
@@ -38,9 +38,7 @@ This rule applies to any element that has:
 
 ## Expectation
 
-The complete [visible text content][] of the target element either matches or is contained within its [accessible name][].
-
-**Note:** Leading and trailing [whitespace][] and difference in case sensitivity should be ignored.
+All [text nodes][] in the [visible text content][] of each target element matches, or is contained within the [accessible name][] of the target element, except for [text nodes][] contains [non-text content][]. Leading and trailing [whitespace][] and difference in case sensitivity should be ignored.
 
 ## Assumptions
 
@@ -81,6 +79,14 @@ This button has [visible][] text that is included in the [accessible name][].
 
 ```html
 <button aria-label="Next Page in the list">Next Page</button>
+```
+
+#### Passed Example 4
+
+This button has [visible][] text that does not need to be included in the [accessible name][], because the "x" text node is [non-text content][].
+
+```html
+<button aria-label="close">X</button>
 ```
 
 ### Failed
@@ -146,16 +152,8 @@ This link has no [visible text content][].
 </a>
 ```
 
-#### Inapplicable Example 5
-
-The content of this link is [non-text content][].
-
-```html
-<button aria-label="close">X</button>
-```
-
 [accessible name]: #accessible-name 'Definition of accessible name'
-[non-text content]: https://www.w3.org/TR/WCAG21/#dfn-non-text-content 'Definition of Non-text content'
+[non-text content]: https://www.w3.org/TR/WCAG21/#dfn-non-text-content 'WCAG Definition of Non-text content'
 [presentational roles conflict resolution]: https://www.w3.org/TR/wai-aria-1.1/#conflict_resolution_presentation_none 'Presentational Roles Conflict Resolution'
 [semantic role]: #semantic-role 'Definition of Semantic role'
 [supports name from content]: https://www.w3.org/TR/wai-aria-1.1/#namefromcontent 'Definition of Supports name from contents'

--- a/_rules/visible-label-in-accessible-name-2ee8b8.md
+++ b/_rules/visible-label-in-accessible-name-2ee8b8.md
@@ -38,7 +38,7 @@ This rule applies to any element that has:
 
 ## Expectation
 
-All [text nodes][] in the [visible text content][] of each target element matches, or is contained within the [accessible name][] of the target element, except for characters used to express [non-text content][]. Leading and trailing [whitespace][] and difference in case sensitivity should be ignored.
+For each target element, all [text nodes][] in the [visible text content][] either matches or is contained within the [accessible name][] of this target element, except for characters in the [text nodes][] used to express [non-text content][]. Leading and trailing [whitespace][] and difference in case sensitivity should be ignored.
 
 ## Assumptions
 

--- a/pages/glossary/visible-text-content.md
+++ b/pages/glossary/visible-text-content.md
@@ -2,12 +2,16 @@
 title: Visible Text Content
 key: visible-text-content
 unambiguous: true
-objective: false
+objective: true
 input_aspects:
   - CSS styling
   - DOM tree
 ---
 
-Elements that are [visible](#visible), that are of type text, excluding text content in `title` or `alt` attributes, and are not categorized as [non text content](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content).
+The _visible text content_ of an [element][] is a set of all [visible][] [text node][] that are a [descendant][] in the [flat tree][] of the element.
 
-**Note:** These elements should also be ensured to meet the color contrast and visibility requirements.
+[descendant]: https://dom.spec.whatwg.org/#concept-tree-descendant 'DOM tree descendant, 2020/08/18'
+[element]: https://dom.spec.whatwg.org/#element 'DOM element, 2020/08/18'
+[flat tree]: https://drafts.csswg.org/css-scoping/#flat-tree 'CSS draft, flat tree, 2020/08/18'
+[visible]: #visible
+[text node]: https://dom.spec.whatwg.org/#text 'DOM text, 2020/08/18'

--- a/pages/glossary/visible-text-content.md
+++ b/pages/glossary/visible-text-content.md
@@ -8,10 +8,10 @@ input_aspects:
   - DOM tree
 ---
 
-The _visible text content_ of an [element][] is a set of all [visible][] [text node][] that are a [descendant][] in the [flat tree][] of the element.
+The _visible text content_ of an [element][] is a set of all [visible][] [text nodes][] that are [descendants][] in the [flat tree][] of this element
 
-[descendant]: https://dom.spec.whatwg.org/#concept-tree-descendant 'DOM tree descendant, 2020/08/18'
+[descendants]: https://dom.spec.whatwg.org/#concept-tree-descendant 'DOM tree descendant, 2020/08/18'
 [element]: https://dom.spec.whatwg.org/#element 'DOM element, 2020/08/18'
 [flat tree]: https://drafts.csswg.org/css-scoping/#flat-tree 'CSS draft, flat tree, 2020/08/18'
 [visible]: #visible
-[text node]: https://dom.spec.whatwg.org/#text 'DOM text, 2020/08/18'
+[text nodes]: https://dom.spec.whatwg.org/#text 'DOM text, 2020/08/18'


### PR DESCRIPTION
- Because the definition of Visible text content is used in the applicability, it can not be subjective.
- Add a ligature font passed example

Closes #1254, closes #975

Need for Final Call: 1 week