### PR TITLE
test: ensure authors are ordered alphabetically

### DIFF
--- a/__tests__/frontmatter.js
+++ b/__tests__/frontmatter.js
@@ -78,6 +78,14 @@ function validateRuleFrontmatter({ frontmatter }, metaData) {
 	test.each([...authors, ...previous_authors])('has contributor data for author: `%s`', author => {
 		expect(metaData.contributors).toContain(author.toLowerCase())
 	})
+	const orderedAuthors = [...authors].sort((a, b) => a.localeCompare(b))
+	test('authors are ordered alphabetically', () => {
+		expect(authors).toStrictEqual(orderedAuthors)
+	})
+	const orderePreviousAuthors = [...previous_authors].sort((a, b) => a.localeCompare(b))
+	test('previous authors are ordered alphabetically', () => {
+		expect(previous_authors).toStrictEqual(orderePreviousAuthors)
+	})
 
 	/**
 	 * Check if `accessibility_requirements` (if any) has expected values

--- a/__tests__/frontmatter.js
+++ b/__tests__/frontmatter.js
@@ -82,9 +82,9 @@ function validateRuleFrontmatter({ frontmatter }, metaData) {
 	test('authors are ordered alphabetically', () => {
 		expect(authors).toStrictEqual(orderedAuthors)
 	})
-	const orderePreviousAuthors = [...previous_authors].sort((a, b) => a.localeCompare(b))
+	const orderedPreviousAuthors = [...previous_authors].sort((a, b) => a.localeCompare(b))
 	test('previous authors are ordered alphabetically', () => {
-		expect(previous_authors).toStrictEqual(orderePreviousAuthors)
+		expect(previous_authors).toStrictEqual(orderedPreviousAuthors)
 	})
 
 	/**


### PR DESCRIPTION
Adding a test which checks the rule's frontmatter to ensure authors & previous authors are ordered alphabetically.

Closes issue(s):
- NA

Need for Final Call:
- None
