### PR TITLE
fix inconsistent name in avoid-autoplay atomic rule

### DIFF
--- a/_rules/audio-or-video-avoids-automatically-playing-audio-80f0bf.md
+++ b/_rules/audio-or-video-avoids-automatically-playing-audio-80f0bf.md
@@ -55,7 +55,7 @@ This rule applies to any `audio` or `video` element that has:
 For each test target, the outcome of at least one of the following rules is passed:
 
 - [Audio Or Video That Plays Automatically Has A Control Mechanism](https://act-rules.github.io/rules/4c31df)
-- [Audio Or Video That Plays Automatically Does Not Exceed 3 Seconds](https://act-rules.github.io/rules/aaa1bf)
+- [Audio Or Video That Plays Automatically Has No Audio That Lasts More Than 3 Seconds](https://act-rules.github.io/rules/aaa1bf)
 
 ## Assumptions
 


### PR DESCRIPTION
As @adilsofficial described, the name of this atomic rule was changed, but the composite rule associated with it was not.

Closes #1427

Need for Final Call: none