### PR TITLE
Clearing issues related to `autocomplete` attribute has valid value

### DIFF
--- a/__tests__/frontmatter.js
+++ b/__tests__/frontmatter.js
@@ -78,6 +78,14 @@ function validateRuleFrontmatter({ frontmatter }, metaData) {
 	test.each([...authors, ...previous_authors])('has contributor data for author: `%s`', author => {
 		expect(metaData.contributors).toContain(author.toLowerCase())
 	})
+	const orderedAuthors = [...authors].sort((a, b) => a.localeCompare(b))
+	test('authors are ordered alphabetically', () => {
+		expect(authors).toStrictEqual(orderedAuthors)
+	})
+	const orderedPreviousAuthors = [...previous_authors].sort((a, b) => a.localeCompare(b))
+	test('previous authors are ordered alphabetically', () => {
+		expect(previous_authors).toStrictEqual(orderedPreviousAuthors)
+	})
 
 	/**
 	 * Check if `accessibility_requirements` (if any) has expected values

--- a/__tests__/spelling-ignore.yml
+++ b/__tests__/spelling-ignore.yml
@@ -206,3 +206,7 @@
 - cantTell
 - TestSubject
 - earl:cantTell
+
+# Language codes
+- da
+- nl

--- a/_rules/audio-or-video-avoids-automatically-playing-audio-80f0bf.md
+++ b/_rules/audio-or-video-avoids-automatically-playing-audio-80f0bf.md
@@ -55,7 +55,7 @@ This rule applies to any `audio` or `video` element that has:
 For each test target, the outcome of at least one of the following rules is passed:
 
 - [Audio Or Video That Plays Automatically Has A Control Mechanism](https://act-rules.github.io/rules/4c31df)
-- [Audio Or Video That Plays Automatically Does Not Exceed 3 Seconds](https://act-rules.github.io/rules/aaa1bf)
+- [Audio Or Video That Plays Automatically Has No Audio That Lasts More Than 3 Seconds](https://act-rules.github.io/rules/aaa1bf)
 
 ## Assumptions
 

--- a/_rules/autocomplete-valid-value-73f2c2.md
+++ b/_rules/autocomplete-valid-value-73f2c2.md
@@ -21,39 +21,35 @@ acknowledgments:
 
 ## Applicability
 
-The rule applies to any HTML `input`, `select` and `textarea` element with an `autocomplete` attribute that is a set of one or more [space separated tokens](https://html.spec.whatwg.org/#set-of-space-separated-tokens), except if one of the following is true:
+The rule applies to any HTML `input`, `select` and `textarea` element with an `autocomplete` [attribute value][] that is neither empty (`""`) nor only [ASCII whitespace][], except if one of the following is true:
 
-- The element is not [visible](#visible), and not [included in the accessibility tree](#included-in-the-accessibility-tree)
-- The element is an `input` element with a `type` [attribute value][] of either `hidden`, `button`, `submit` or `reset`
-- The element has an `aria-disabled` [attribute value][] of `true`
-- The element is not part of [sequential focus navigation](https://html.spec.whatwg.org/#sequential-focus-navigation) and has a [semantic role](#semantic-role) that is not a [widget role](https://www.w3.org/TR/wai-aria-1.1/#widget_roles).
+- **hidden**: the element is not [visible][], and not [included in the accessibility tree][]; or
+- **disabled**: the element has an `aria-disabled` [attribute value][] of `true`; or
+- **fixed value**: the element is an `input` element with a `type` [attribute value][] of either `hidden`, `button`, `submit` or `reset`; or
+- **static**: the element is not part of [sequential focus navigation][] and has a [semantic role][] that is not a [widget role][].
 
 ## Expectation 1
 
-The `autocomplete` attribute is a single term, or a space separated list of terms.
+Each test target's `autocomplete` [attribute value][] is a [space separated][] list of one or more tokens that follow the [HTML specification for Autofill detail tokens][], which requires that the token list match the following in the correct order:
+
+1. An optional token that starts with "section-"; then
+2. An optional token of either "shipping" or "billing"; then
+3. An optional token of either "home", "work", "mobile", "fax" or "pager", only if the last token is "email", "impp", "tel" or "tel-*"; then
+4. A required token from the [correct autocomplete field][].
 
 ## Expectation 2
 
-The autocomplete term(s) follow the [HTML specification - Autofill detail tokens](https://html.spec.whatwg.org/#autofill-detail-tokens), which requires that it/they match the following in the correct order:
-
-1. Has a value that starts with "section-" _(optional)_
-2. Has either "shipping" or "billing" _(optional)_
-3. Has either "home", "work", "mobile", "fax" or "pager" _(optional, only for "email", "impp", "tel" or "tel-\*")_
-4. Has a [correct autocomplete field](#correct-autocomplete-field) _(required)_
-
-**Note:** Autocomplete terms are case insensitive. When multiple terms are used, they must be used in the correct order.
-
-## Expectation 3
-
-The [correct autocomplete field](#correct-autocomplete-field) is an [appropriate field for the form control](#appropriate-field-for-the-form-control).
+Each test target's `autocomplete` [attribute value][] has a [correct autocomplete field][] that is an [appropriate][appropriate field for the form control] for that test target.
 
 ## Assumptions
 
-For this rule, it is assumed that the `autocomplete` attribute is not used on form fields that do not correspond to an autocomplete field described in the HTML 5.2 specification. If the `autocomplete` field is used to describe "custom" taxonomy, rather than that described in the specification, this rule may produce incorrect results.
+The `autocomplete` attribute is not used on form fields that do not correspond to an autocomplete field described in the HTML 5.2 specification. If the `autocomplete` field is used to describe "custom" taxonomy, rather than that described in the specification, success Criterion [1.3.5 Identify Input Purpose][sc135] may be satisfied even if this rule failed. 
+
+The `type` attribute is used correctly according to the intended purpose of `input` elements. If an incorrect `type` attribute is used for `input` elements, this rule may fail elements that satisfy success Criterion [1.3.5 Identify Input Purpose][sc135]. For example if an `input` element has a `type` of `number`, but is expecting an e-mail address.
 
 ## Accessibility Support
 
-- While `autocomplete` in a promising technique for supporting personalization in HTML, support for this is fairly limited.
+- While `autocomplete` is a promising technique for supporting personalization in HTML, support for this in assistive technologies is fairly limited.
 - Implementation of [Presentational Roles Conflict Resolution][] varies from one browser or assistive technology to another. Depending on this, some elements can have a [semantic role][] of `none` and fail this rule with some technology but users of other technologies would not experience any accessibility issue.
 - Some user agents treat the value of the `aria-disabled` attribute as case-sensitive.
 
@@ -71,7 +67,7 @@ The intent of this rule is to ensure that the `autocomplete` attribute can be us
 
 #### Passed Example 1
 
-Single autocomplete term.
+This `autocomplete` [attribute value][] only has the required token, and is valid for an `input` element which has a default type of `text`.
 
 ```html
 <label>Username<input autocomplete="username"/></label>
@@ -79,7 +75,7 @@ Single autocomplete term.
 
 #### Passed Example 2
 
-Single autocomplete term for select.
+This `autocomplete` [attribute value][] only has the required token, and is valid for a `select` element.
 
 ```html
 <select autocomplete="bday-month">
@@ -90,7 +86,7 @@ Single autocomplete term for select.
 
 #### Passed Example 3
 
-Autocomplete term, only valid for textarea.
+This `autocomplete` [attribute value][] only has the required token, and is valid for a `textarea` element. Mixing upper and lower case letters is allowed for `autocomplete` attributes.
 
 ```html
 <textarea autocomplete="Street-Address"></textarea>
@@ -98,7 +94,7 @@ Autocomplete term, only valid for textarea.
 
 #### Passed Example 4
 
-Two autocomplete terms.
+This `autocomplete` [attribute value][] list includes a `work` token, allowed because it is used before `email`. The `email` token is allowed on `input` elements with a `type` [attribute value][] of `text`.
 
 ```html
 <label>Work email<input autocomplete="Work Email"/></label>
@@ -106,7 +102,7 @@ Two autocomplete terms.
 
 #### Passed Example 5
 
-Autocomplete using section-\*
+This `autocomplete` [attribute value][] list includes a `section-` token, which can preface any [correct autocomplete field][]. The `email` token is allowed on `input` elements with a `type` [attribute value][] of `text`.
 
 ```html
 <label>Email<input autocomplete="section-partner email"/></label>
@@ -114,7 +110,7 @@ Autocomplete using section-\*
 
 #### Passed Example 6
 
-Triple autocomplete terms.
+This `autocomplete` [attribute value][] list includes `section-`  and `billing` tokens. These tokens can preface any [correct autocomplete field][]. 
 
 ```html
 <label>Address<input type="text" autocomplete="section-primary billing address-line1"/></label>
@@ -122,31 +118,15 @@ Triple autocomplete terms.
 
 #### Passed Example 7
 
-Full length autocomplete terms.
+This `autocomplete` [attribute value][] list includes all allowed types of tokens in the correct order. The `email` token is allowed on `input` elements with a `type` [attribute value][] of `text`.
 
 ```html
-<label>Email<input autocomplete="section-primary shipping work email"/></label>
+<label>Email<input type="text" autocomplete="section-primary shipping work email"/></label>
 ```
 
 #### Passed Example 8
 
-This `input` element has an [explicit role][] of `none`. However, it is [focusable][] (by default). Thus it has a [semantic role][] of `textbox` due to [Presentational Roles Conflict Resolution][]. It has a single autocomplete term.
-
-```html
-<label>Username<input role="none" autocomplete="username"/></label>
-```
-
-#### Passed Example 9
-
-The `input` element does not participates in sequential focus navigation, but still has a semantic role that is a widget role, and has a single autocomplete term.
-
-```html
-<label>Username<input tabindex="-1" autocomplete="username"/></label>
-```
-
-#### Passed Example 10
-
-The `input` element does not have a semantic role that is a widget role, but still participates in sequential focus navigation because of the [`tabindex` attribute](https://html.spec.whatwg.org/#the-tabindex-attribute), and has a single autocomplete term.
+The `autocomplete` attribute value is on an `input` element that does not have a semantic role that is a widget role, but still participates in [sequential focus navigation][] because of the `tabindex` attribute.
 
 ```html
 <label>Username<input role="banner" tabindex="0" autocomplete="username"/></label>
@@ -156,7 +136,7 @@ The `input` element does not have a semantic role that is a widget role, but sti
 
 #### Failed Example 1
 
-Unknown autocomplete term.
+This `autocomplete` [attribute value][] has an unknown term that is not a [correct autocomplete field][].
 
 ```html
 <label>Username<input autocomplete="badterm"/></label>
@@ -164,7 +144,7 @@ Unknown autocomplete term.
 
 #### Failed Example 2
 
-Term `work` not allowed before `photo`.
+This `autocomplete` [attribute value][] has the `work` token on a [correct autocomplete field][], however "work" can not be used with "photo".
 
 ```html
 <label>Photo<input autocomplete="work photo"/></label>
@@ -172,7 +152,7 @@ Term `work` not allowed before `photo`.
 
 #### Failed Example 3
 
-Invalid order of terms.
+This `autocomplete` [attribute value][] includes the `work` token before the `shipping` token, instead of the other way around.
 
 ```html
 <label>Email<input autocomplete="work shipping email"/></label>
@@ -180,7 +160,7 @@ Invalid order of terms.
 
 #### Failed Example 4
 
-Comma separated rather than space separated list.
+This `autocomplete` [attribute value][] is comma separated instead of space using [ASCII whitespace][].
 
 ```html
 <label>Email<input autocomplete="work,email"/></label>
@@ -188,17 +168,17 @@ Comma separated rather than space separated list.
 
 #### Failed Example 5
 
-Autocomplete is inappropriate for the type of field.
+This `autocomplete` [attribute value][] is not appropriate for the field. The form field's implied purpose is to input a quantity (a number) which cannot be a e-mail.
 
 ```html
-<label>Email<input type="number" autocomplete="email"/></label>
+<label>Quantity<input type="number" autocomplete="email"/></label>
 ```
 
 ### Inapplicable
 
 #### Inapplicable Example 1
 
-Inapplicable element.
+This `button` element does not support `autocomplete` attributes.
 
 ```html
 <button autocomplete="username"></button>
@@ -206,7 +186,7 @@ Inapplicable element.
 
 #### Inapplicable Example 2
 
-Autocomplete attribute is empty ("").
+This `autocomplete` [attribute value][] is empty ("").
 
 ```html
 <label>Username<input autocomplete=""/></label>
@@ -214,31 +194,31 @@ Autocomplete attribute is empty ("").
 
 #### Inapplicable Example 3
 
-The element is hidden through `display:none`.
+This `autocomplete` [attribute value][] contains only [ASCII whitespace][].
+
+```html
+<label>Username<input autocomplete=" "/></label>
+```
+
+#### Inapplicable Example 4
+
+This `autocomplete` [attribute value][] is on an element that is not [visible][] through `display:none`.
 
 ```html
 <label>Username<input autocomplete="username" style="display:none"/></label>
 ```
 
-#### Inapplicable Example 4
+#### Inapplicable Example 5
 
-The `input` element has a `type` attribute that is in the `button` state.
+This `autocomplete` attribute is on an `input` element with a `type` [attribute value][] that does not support autocomplete.
 
 ```html
 <label>Username<input type="button" autocomplete="username"/></label>
 ```
 
-#### Inapplicable Example 5
-
-The `input` element has a `type` attribute that is in the `hidden` state.
-
-```html
-<label>Username<input type="hidden" autocomplete="username"/></label>
-```
-
 #### Inapplicable Example 6
 
-The `input` element has an HTML `disabled` attribute.
+This `autocomplete` attribute is on an `input` element that has the `disabled` attribute.
 
 ```html
 <label>Username<input autocomplete="username" disabled/></label>
@@ -246,7 +226,7 @@ The `input` element has an HTML `disabled` attribute.
 
 #### Inapplicable Example 7
 
-The `input` element has an `aria-disabled` attribute with value `true`.
+This `autocomplete` attribute is on an `input` element that has the `aria-disabled` [attribute value][] of `true`.
 
 ```html
 <label>Username<input autocomplete="username" aria-disabled="true"/></label>
@@ -254,22 +234,22 @@ The `input` element has an `aria-disabled` attribute with value `true`.
 
 #### Inapplicable Example 8
 
-Non-widget element that does not participate in sequential focus navigation.
+This `autocomplete` attribute is ignored because it is on an element with a [semantic role][] of `none`. The `disabled` attribute is required to ensure [presentational roles conflict resolution][] does not cause the `none` role to be ignored.
 
 ```html
-<label>Username<input type="button" role="none" disabled autocomplete="username"/></label>
+<label>Username<input type="text" role="none" disabled autocomplete="username"/></label>
 ```
 
-#### Inapplicable Example 9
-
-Autocomplete attribute contains no tokens.
-
-```html
-<label>Username<input autocomplete=" "/></label>
-```
-
+[ASCII whitespace]: https://infra.spec.whatwg.org/#ascii-whitespace 'HTML ASCII whitespace 2020/08/12'
 [attribute value]: #attribute-value 'Definition of Attribute Value'
-[explicit role]: #explicit-role 'Definition of explicit role'
-[focusable]: #focusable 'Definition of focusable'
+[appropriate field for the form control]: #appropriate-field-for-the-form-control 'Definition of Appropriate field for the form control'
+[correct autocomplete field]: #correct-autocomplete-field 'Definition of Correct autocomplete field'
+[HTML specification for Autofill detail tokens]: https://html.spec.whatwg.org/#autofill-detail-tokens 'HTML Autofill Detail, 2020/08/12'
+[included in the accessibility tree]: #included-in-the-accessibility-tree 'Definition of Included in the accessibility tree'
 [presentational roles conflict resolution]: https://www.w3.org/TR/wai-aria-1.1/#conflict_resolution_presentation_none 'Presentational Roles Conflict Resolution'
+[sc135]: https://www.w3.org/TR/WCAG21/#identify-input-purpose 'WCAG 2.1 success criterion 1.3.5 Identify Input Purpose'
 [semantic role]: #semantic-role 'Definition of Semantic Role'
+[sequential focus navigation]: https://html.spec.whatwg.org/#sequential-focus-navigation 'HTML sequential focus navigation, 2020/08/12'
+[space separated]: https://html.spec.whatwg.org/#set-of-space-separated-tokens 'HTML Set of space separated tokens 2020/08/12'
+[visible]: #visible 'Definition of Visible'
+[widget role]: https://www.w3.org/TR/wai-aria-1.1/#widget_roles 'WAI-ARIA widget roles'

--- a/_rules/html-page-lang-matches-default-ucwvc8.md
+++ b/_rules/html-page-lang-matches-default-ucwvc8.md
@@ -1,0 +1,300 @@
+---
+id: ucwvc8
+name: HTML page language subtag matches default language
+rule_type: atomic
+description: |
+  This rule checks that the primary language subtag of the page language matches the default language of the page
+accessibility_requirements:
+  wcag20:3.1.1: # Language of Page (A)
+    forConformance: true
+    failed: not satisfied
+    passed: satisfied
+    inapplicable: further testing needed
+  wcag-technique:H57: # Using the language attribute on the HTML element
+    forConformance: false
+    failed: not satisfied
+    passed: satisfied
+    inapplicable: satisfied
+input_aspects:
+  - DOM tree
+  - Accessibility tree
+  - CSS Styling
+  - Language
+acknowledgments:
+  authors:
+    - Wilco Fiers
+htmlHintIgnore:
+  # https://www.npmjs.com/package/htmlhint
+  # using aria-labelledby instead
+  - 'alt-require'
+---
+
+## Applicability
+
+This rule applies to any [document element][] if it is an `html` element for which all of the following are true:
+
+- The [document element][] has a `lang` attribute with a value that is a [valid language tag][]; and
+- The [document element][] is in a [top-level browsing context][]; and
+- The [document element][] has a [content type][] of `text/html`; and
+- The [document element][] has a defined [default page language][].
+
+## Expectation
+
+For each test target, the [primary language][] of the [valid language tag][] matches the [default page language][] of the test target.
+
+## Assumptions
+
+- This rule assumes that the default human language of a page, as described in WCAG 2, can be determined by counting the number of words used in each language. If the default language needs to be derived in some other way (such as frequency analysis, mutual information based distance, …), this rule may fail while [Success Criterion 3.1.1: Language of Page](https://www.w3.org/TR/WCAG21/#language-of-page) is still satisfied.
+
+- The language of the page can be set by other methods than the `lang` attribute, for example using HTTP headers or the `meta` element. These methods are not supported by all assistive technologies. This rule assumes that these other methods are insufficient to satisfying [Success Criterion 3.1.1: Language of Page](https://www.w3.org/TR/WCAG21/#language-of-page).
+
+- This rule assumes that user agents and assistive technologies can programmatically determine [valid language tags](#valid-language-tag) even if these do not conform to the [BCP 47][] syntax.
+
+- This rule assumes that [grandfathered tags][] are not used as these will not be recognized as [valid language tags](#valid-language-tag).
+
+- This rule assumes that `iframe` title elements are not exposed to assistive technologies and so does not consider them as part of the [default page language][].
+
+## Accessibility Support
+
+_There are no major accessibility support issues known for this rule._
+
+## Background
+
+- [Understanding Success Criterion 3.1.1: Language of Page](https://www.w3.org/WAI/WCAG21/Understanding/language-of-page.html)
+- [H57: Using language attributes on the html element](https://www.w3.org/WAI/WCAG21/Techniques/html/H57)
+- [BCP 47: Tags for Identifying Languages](https://www.ietf.org/rfc/bcp/bcp47.txt)
+- [The `lang` and `xml:lang` attributes](https://html.spec.whatwg.org/multipage/dom.html#the-lang-and-xml:lang-attributes)
+
+## Test Cases
+
+### Passed
+
+#### Passed Example 1
+
+This page has a `lang` [attribute value][] of `en` (English), which matches the [default language of the page][default page language]. The default language is English because all words are English.
+
+```html
+<html lang="en">
+	<head>
+		<title>ACT Rules Format 1.0 - Abstract</title>
+	</head>
+	<body>
+		<p>
+			The Accessibility Conformance Testing (ACT) Rules Format 1.0 defines a format for writing accessibility test
+			rules. These test rules can be used for developing automated testing tools and manual testing methodologies. It
+			provides a common format that allows any party involved in accessibility testing to document and share their
+			testing procedures in a robust and understandable manner. This enables transparency and harmonization of testing
+			methods, including methods implemented by accessibility test tools.
+		</p>
+	</body>
+</html>
+```
+
+#### Passed Example 2
+
+This page has a `lang` attribute value of `en` (English), which matches the [default language of the page][default page language]. The default language is English because all but a few words are English.
+
+```html
+<html lang="en">
+	<head>
+		<title>Gelukkig</title>
+	</head>
+	<body>
+		<p>The Dutch word "gelukkig" has no equivalent in English.</p>
+	</body>
+</html>
+```
+
+#### Passed Example 3
+
+This page has `lang` attribute value of `nl` (Dutch), which matches the [default language of the page][default page language]. The default language is Dutch because all English words are in a `p` element with a `lang` attribute value of `en`.
+
+```html
+<html lang="nl">
+	<head>
+		<title>Met de kippen op stok</title>
+	</head>
+	<body>
+		<blockquote>
+			<p>"Hij ging met de kippen op stok"</p>
+		</blockquote>
+		<p lang="en">
+			This Dutch phrase literally translates into "He went to roost with the chickens", but it means that he went to bed
+			early.
+		</p>
+	</body>
+</html>
+```
+
+#### Passed Example 4
+
+This page has a `lang` attribute value of `en` (English), which matches the [default language of the page][default page language]. The default language is English because the accessible texts are English, and all other text is in a `p` element with a `lang` attribute value of `nl`.
+
+```html
+<html lang="en">
+	<head>
+		<title>Fireworks over Paris</title>
+	</head>
+	<body>
+		<img src="/test-assets/shared/fireworks.jpg" alt="Fireworks over Paris" />
+		<p lang="nl">
+			Gelukkig nieuwjaar!
+		</p>
+	</body>
+</html>
+```
+
+### Failed
+
+#### Failed Example 1
+
+This page has `lang` attribute value of `da` (Danish), which does not matches the [default language of the page][default page language]. The default language is English because all words are English.
+
+```html
+<html lang="da">
+	<head>
+		<title>ACT Rules Format 1.0 - Abstract</title>
+	</head>
+	<body>
+		<p>
+			The Accessibility Conformance Testing (ACT) Rules Format 1.0 defines a format for writing accessibility test
+			rules. These test rules can be used for developing automated testing tools and manual testing methodologies. It
+			provides a common format that allows any party involved in accessibility testing to document and share their
+			testing procedures in a robust and understandable manner. This enables transparency and harmonization of testing
+			methods, including methods implemented by accessibility test tools.
+		</p>
+	</body>
+</html>
+```
+
+#### Failed Example 2
+
+This page has a `lang` attribute value of `nl` (Dutch), which does not match the [default language of the page][default page language]. The default language is English because all but a few words are English.
+
+```html
+<html lang="nl">
+	<head>
+		<title>Gelukkig</title>
+	</head>
+	<body>
+		<p>The Dutch word "gelukkig" has no equivalent in English.</p>
+	</body>
+</html>
+```
+
+#### Failed Example 3
+
+This page has `lang` attribute value of `en` (English), which does not matches the [default language of the page][default page language]. The default language is Dutch because all English words are in a `p` element with a `lang` attribute value of `en`.
+
+```html
+<html lang="en">
+	<head>
+		<title>Met de kippen op stok</title>
+	</head>
+	<body>
+		<blockquote>
+			<p>"Hij ging met de kippen op stok"</p>
+		</blockquote>
+		<p lang="en">
+			This Dutch phrase literally translates into "He went to roost with the chickens", but it means that he went to bed
+			early.
+		</p>
+	</body>
+</html>
+```
+
+#### Failed Example 4
+
+This page has a `lang` attribute value of `nl` (Dutch), which does not match the [default language of the page][default page language]. The default language is English because the accessible texts are English, and all other text is in a `p` element with a `lang` attribute value of `nl`.
+
+```html
+<html lang="nl">
+	<head>
+		<title>Fireworks over Paris</title>
+	</head>
+	<body>
+		<img src="/test-assets/shared/fireworks.jpg" alt="Fireworks over Paris" />
+		<p lang="nl">
+			Gelukkig nieuwjaar!
+		</p>
+	</body>
+</html>
+```
+
+#### Failed Example 5
+
+This page has a `lang` attribute value of `nl` (Dutch), which does not match the [default language of the page][default page language]. The default language is English because the accessible name of the `img` element is English. The `lang` attribute on the `p` element is effectively ignored.
+
+```html
+<html lang="nl">
+	<head>
+		<title>Paris</title>
+	</head>
+	<body>
+		<img src="/test-assets/shared/fireworks.jpg" aria-labelledby="caption" />
+		<p lang="en" id="caption" hidden>
+			Fireworks over Paris!
+		</p>
+	</body>
+</html>
+```
+
+### Inapplicable
+
+#### Inapplicable Example 1
+
+This is an SVG [document][document element], not an HTML document.
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" lang="fr"></svg>
+```
+
+#### Inapplicable Example 2
+
+This page has an undefined [default language][default page language] because it has no content or [document title][].
+
+```html
+<html></html>
+```
+
+#### Inapplicable Example 3
+
+This page has an undefined [default language][default page language] because it has no [document title][] and all its content is wrapped in an element with a `lang` attribute.
+
+```html
+<html>
+	<p lang="en">
+		The Accessibility Conformance Testing (ACT) Rules Format 1.0 defines a format for writing accessibility test rules.
+		These test rules can be used for developing automated testing tools and manual testing methodologies. It provides a
+		common format that allows any party involved in accessibility testing to document and share their testing procedures
+		in a robust and understandable manner. This enables transparency and harmonization of testing methods, including
+		methods implemented by accessibility test tools.
+	</p>
+</html>
+```
+
+#### Inapplicable Example 4
+
+This page has an undefined [default language][default page language] because it can either be English or French.
+
+```html
+<html lang="fr">
+	<head>
+		<title>Paul put dire comment on tape</title>
+	</head>
+	<body>
+		<p>Paul put dire comment on tape</p>
+	</body>
+</html>
+```
+
+[valid language tag]: #valid-language-tag
+[default page language]: #default-page-language
+[attribute value]: #attribute-value
+[primary language]: https://tools.ietf.org/html/bcp47#section-2.2.1 'Definition of primary language subtag'
+[grandfathered tags]: https://tools.ietf.org/html/bcp47#section-2.2.8
+[bcp 47]: https://tools.ietf.org/html/bcp47#section-2.1
+[document element]: https://dom.spec.whatwg.org/#document-element 'DOM document element, as of 2020/06/05'
+[content type]: https://dom.spec.whatwg.org/#concept-document-content-type 'DOM content type, as of 2020/06/05'
+[document title]: https://html.spec.whatwg.org/multipage/dom.html#document.title 'HTML document title, as of 2020/06/05'
+[top-level browsing context]: https://html.spec.whatwg.org/#top-level-browsing-context 'HTML top-level browsing context, as of 2020/06/05'

--- a/_rules/object-has-acessible-name-8fc3b6.md
+++ b/_rules/object-has-acessible-name-8fc3b6.md
@@ -35,7 +35,7 @@ _There are currently no assumptions._
 
 ## Accessibility Support
 
-Non supported media formats make screen readers render the text content of the element instead of other attributes.
+Non-supported media formats make screen readers render the text content of the element instead of other attributes.
 
 ## Background
 

--- a/_rules/visible-label-in-accessible-name-2ee8b8.md
+++ b/_rules/visible-label-in-accessible-name-2ee8b8.md
@@ -36,9 +36,7 @@ This rule applies to any element for which all the following is true:
 
 ## Expectation
 
-The complete [visible text content][] of the target element either matches or is contained within its [accessible name][].
-
-**Note:** Leading and trailing [whitespace][] and difference in case sensitivity should be ignored.
+For each target element, all [text nodes][] in the [visible text content][] either match or are contained within the [accessible name][] of this target element, except for characters in the [text nodes][] used to express [non-text content][]. Leading and trailing [whitespace][] and difference in case sensitivity should be ignored.
 
 ## Assumptions
 
@@ -81,6 +79,28 @@ This button has [visible][] text that is included in the [accessible name][].
 
 ```html
 <button aria-label="Next Page in the list">Next Page</button>
+```
+
+#### Passed Example 4
+
+This button has [visible][] text that does not need to be included in the [accessible name][], because the "x" text node is [non-text content][].
+
+```html
+<button aria-label="close">X</button>
+```
+
+#### Passed Example 5
+
+This `button` element has the text "search" rendered as an hourglass icon by the font. Because the text is rendered as [non-text content][], the text does not need to be included in the [accessible name][].
+
+```html
+<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+<style>
+	button {
+		font-family: 'Material Icons';
+	}
+</style>
+<button aria-label="Find">search</button>
 ```
 
 ### Failed
@@ -146,16 +166,8 @@ This link has no [visible text content][].
 </a>
 ```
 
-#### Inapplicable Example 5
-
-The content of this link is [non-text content][].
-
-```html
-<button aria-label="close">X</button>
-```
-
 [accessible name]: #accessible-name 'Definition of accessible name'
-[non-text content]: https://www.w3.org/TR/WCAG21/#dfn-non-text-content 'Definition of Non-text content'
+[non-text content]: https://www.w3.org/TR/WCAG21/#dfn-non-text-content 'WCAG Definition of Non-text content'
 [presentational roles conflict resolution]: https://www.w3.org/TR/wai-aria-1.1/#conflict_resolution_presentation_none 'Presentational Roles Conflict Resolution'
 [semantic role]: #semantic-role 'Definition of Semantic role'
 [supports name from content]: https://www.w3.org/TR/wai-aria-1.1/#namefromcontent 'Definition of Supports name from contents'
@@ -163,3 +175,4 @@ The content of this link is [non-text content][].
 [visible text content]: #visible-text-content 'Definition of Visible text content'
 [whitespace]: #whitespace 'Definition of Whitespace'
 [widget roles]: https://www.w3.org/TR/wai-aria-1.1/#widget_roles 'Definition of Widget role'
+[text nodes]: https://dom.spec.whatwg.org/#text 'DOM text, 2020/08/18'

--- a/pages/design/rule-design.md
+++ b/pages/design/rule-design.md
@@ -149,7 +149,7 @@ The description should:
 
 > _For example: "This page has a `title` element with content."_
 
-For more details, see [ACT Rules Format: Test Cases](https://www.w3.org/TR/act-rules-format/#test-cases).
+For a detailed description on what to write test cases for see [test case design](test-cases.html). For more details, see [ACT Rules Format: Test Cases](https://www.w3.org/TR/act-rules-format/#test-cases).
 
 ## Listed conditions
 

--- a/pages/design/test-cases.md
+++ b/pages/design/test-cases.md
@@ -1,0 +1,70 @@
+# ACT Rules Test Case Design
+
+The goal of test cases in ACT rules is to allow implementers to verify that their implementation is consistent with the ACT rule. It requires that a rule has test cases for all of the "important" aspects of it. Beyond that, it is up to the rule authors to determine how extensive to make the list of test cases. The decision of what the edge cases to test will be,  should be based on issues in **real-world** examples.
+
+To strike a good balance in test cases, the following principles should be considered:
+
+1. Test every "condition" in the rule
+1. Test one thing at a time
+1. Ensure consistency with accessibility
+1. Keep test cases small
+1. Test definitions superficially
+1. Avoid tests cases contested by (accessibility) support
+
+Keep in mind, there are exceptions to all of these.
+
+## Test Every Condition
+
+At a minimum, every "condition" in the applicability and expectation has to have both positive and negative test cases for it. For example the phrase "`img` and `svg` elements" has two conditions in it; "`img` elements" and "`svg` elements". A rule with such a phrase in the applicability would require the following test cases:
+
+- `img` that passes the rule
+- `svg` that passes the rule
+- `img` that fails the rule
+- `svg` that fails the rule
+- some other element that is inapplicable
+
+Providing these test cases ensures that an implementer that correctly tests `img` elements, but passes every `svg` element can be identified as a partial implementation, and one where it fails all `svg` elements is identified as an inconsistent implementation.
+
+## One Thing At A Time
+
+A test case should only test one "condition" at a time. This keeps them focused and easy to reason about. It may be tempting to combine multiple cases in one example, but then if that example does not get the expected outcome, it is difficult to identify the cause of the issue.
+
+When writing test cases, it is important to look at conditional logic. For example if the applicability says an element is applicable if it is "_visible_ and _included in the accessibility tree_", in addition to a passed and failed example, there are three ways for this to not be true, all of which have to be tested:
+
+- inapplicable: visible, but **not** included in the accessibility tree
+- inapplicable: **not** visible, but included in the accessibility tree
+- inapplicable: **not** visible, and **not** included in the accessibility tree
+
+## Consistency With Accessibility Requirements
+
+In order for the mapping of implementations to the rules to work, test cases need to be consistent with the accessibility requirement. This requires that **passed and inapplicable test cases should satisfy the accessibility requirements** of the rule, as well as the accessibility requirement of any composite rule this rule is designed for. Inapplicable conditions that do not satisfy the accessibility requirements should not be included. For example when testing [2.4.2 Page Titled](https://www.w3.org/TR/WCAG21/#page-titled), a rule that tests that titles are descriptive can not have an inapplicable example of a page that should have a title but does not.
+
+Related to this, failed test cases should only fail the accessibility requirements for one reason. A failed test case for 4.1.2 Name, Role, Value should not have issues with both the accessible name, and the role. If the rule is about accessible names, the role and value must be correct.
+
+## Small Test Cases
+
+A general principle in test design is to keep test cases small. Avoid any unnecessary content, as it may cause unexpected side effects in the outcome. For example, a rule about buttons does not require that all test cases have an HTML element with a `lang` attribute and a `title` element. Those elements do not affect the accessibility of a button. All code in the test case should be relevant to the rule or its accessibility requirements.
+
+An exception to that, is that ACT Rules should strive to show good accessibility practices. A rule about valid `autocomplete` attributes should still provide labels for the form controls with the `autocomplete` attribute. Those labels both provide context, showing the intended purpose of the input, and they show good practice of providing labels for form controls.
+
+## Superficial Definition Testing
+
+ACT rules use definitions to avoid duplication, and to "hide" away the details. Definitions such as "semantic role", "visible" and "accessible name" are used in many rules, and are fundamental building blocks of ACT. To avoid having a lot of similar test cases in every rule that uses a particular definition, it is best to keep definition testing to a minimum.
+
+As an example, the "X has non-empty accessible name" rules all have test cases that check for the different ways that an element can have an accessible name. For `img`, that is `alt`, `title`, and `aria-label(ledby)` attributes. That creates sufficient coverage to ensure the basics are understood. But those rules do not go into the details of ensuring accessible name computation is done right. Whether an implementer considers `aria-owns` in the accessible name computation is not relevant for "non-empty accessible name" rules.
+
+That is not to say edge cases in definitions should never have test cases. If there are **real-world examples** of a particular edge case affecting the outcome of a rule, test cases should be added to the rule to cover that edge case.
+
+## Avoid (Accessibility) Support Issues
+
+It is fairly common for rules to involve technologies that are not fully supported. For example, ARIA roles get added every few years, and it takes a while for new roles to get adopted by assistive technologies. In the case that a particular technology has very little or no support at all, the rules should not have test cases for this.
+
+Once there is significant support for a particular technology, it should be considered for test cases. The best way to introduce technologies that are only partially supported is to exclusively provide failed test cases for them. This makes an implementation that does not support this technology partially consistent.
+
+Technologies that are widely supported can be used in all test cases. In all situations, previous principles of deciding if a test case is needed or not still apply.
+
+## Exceptions
+
+It is important to know that there are exceptions to all of these principles. There may be technical reasons not to include a certain test case, or the number of combinations may require an unreasonable number of tests. It may sometimes not make logical sense for some passed test cases to satisfy all accessibility requirements. Some definitions may not require tests, and others can be argued to need extensive tests. Etc.
+
+Letting **real-world** examples drive consistency forward also means rule authors should not get stuck in trying to write test cases for every conceivable situation. Rule authors should strive for a 95% consistency between implementers on first publication. This percentage does not need to be measured, it is intended to give a idea of what to aim for. As more examples are discovered, this number will go up over time.

--- a/pages/glossary/default-page-language.md
+++ b/pages/glossary/default-page-language.md
@@ -1,0 +1,37 @@
+---
+title: Default Page Language
+key: default-page-language
+unambiguous: true
+objective: true
+input_aspects:
+  - DOM tree
+  - Accessibility tree
+  - CSS Styling
+  - Language
+---
+
+The default page language is the _most common language_ used in a [web page][]. If there are no _words_ in the page, the default language is undefined.
+
+The _most common language_ is determined by counting the number of _words_ in the [web page][] that are part of any of the languages in the [language subtag registry][]. The same word can be part of multiple languages. If the number of words is the same, the default language is undefined.
+
+The _words_ used in the following texts should be counted for the _most common language_:
+
+- **page title**: The value of the [document title][] of the [document][] in the [top-level browsing context][].
+- **text nodes**: The value of any [text nodes][] that are [visible][] or [included in the accessibility tree][]
+- **accessible text**: The [accessible name][] and [accessible description][] of any element included in the accessibility tree
+
+**Exception**: Do not count words in text that comes from nodes that have an [ancestor][] in the [flat tree][] which has a non-empty (`""`) `lang` attribute and is not the [root node][]. For accessible texts, only ancestors of the node with the accessible name is considered, the ancestry of nodes used in producing the accessible text are ignored, such as those referenced with aria-labelledby.
+
+[visible]: #visible
+[web page]: #web-page-html
+[included in the accessibility tree]: #included-in-the-accessibility-tree
+[accessible name]: #accessible-name
+[accessible description]: https://www.w3.org/TR/accname-1.1/#dfn-accessible-description 'Definition of Accessible description'
+[language subtag registry]: http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
+[document title]: https://html.spec.whatwg.org/multipage/dom.html#document.title 'HTML document title, as of 2020/06/05'
+[document]: https://dom.spec.whatwg.org/#document-element 'DOM document element, as of 2020/06/05'
+[text nodes]: https://dom.spec.whatwg.org/#text 'DOM text, as of 2020/06/05'
+[ancestor]: https://dom.spec.whatwg.org/#concept-tree-ancestor 'DOM ancestor, as of 2020/06/05'
+[top-level browsing context]: https://html.spec.whatwg.org/#top-level-browsing-context 'HTML top-level browsing context, as of 2020/06/05'
+[flat tree]: https://drafts.csswg.org/css-scoping/#flat-tree 'CSS draft, flat tree, 2020/06/05'
+[root node]: https://dom.spec.whatwg.org/#concept-tree-root 'DOM tree root, as of 2020/06/05'

--- a/pages/glossary/semantic-role.md
+++ b/pages/glossary/semantic-role.md
@@ -23,5 +23,5 @@ The _semantic role_ of an element is determined by the first of these cases that
 [hidden state]: #hidden-state 'Definition of hidden state'
 [implicit role]: #implicit-role 'Definition of Implicit Role'
 [included in the accessibility tree]: #included-in-the-accessibility-tree 'Definition of Included in the Accessibility Tree'
-[marked as decorative]: marked-as-decorative.md 'Definition of Marked as Decorative'
+[marked as decorative]: #marked-as-decorative 'Definition of Marked as Decorative'
 [presentational roles conflict resolution]: https://www.w3.org/TR/wai-aria-1.1/#conflict_resolution_presentation_none 'Presentational Roles Conflict Resolution'

--- a/pages/glossary/visible-text-content.md
+++ b/pages/glossary/visible-text-content.md
@@ -2,12 +2,16 @@
 title: Visible Text Content
 key: visible-text-content
 unambiguous: true
-objective: false
+objective: true
 input_aspects:
   - CSS styling
   - DOM tree
 ---
 
-Elements that are [visible](#visible), that are of type text, excluding text content in `title` or `alt` attributes, and are not categorized as [non text content](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content).
+The _visible text content_ of an [element][] is a set of all [visible][] [text nodes][] that are [descendants][] in the [flat tree][] of this element
 
-**Note:** These elements should also be ensured to meet the color contrast and visibility requirements.
+[descendants]: https://dom.spec.whatwg.org/#concept-tree-descendant 'DOM tree descendant, 2020/08/18'
+[element]: https://dom.spec.whatwg.org/#element 'DOM element, 2020/08/18'
+[flat tree]: https://drafts.csswg.org/css-scoping/#flat-tree 'CSS draft, flat tree, 2020/08/18'
+[visible]: #visible
+[text nodes]: https://dom.spec.whatwg.org/#text 'DOM text, 2020/08/18'


### PR DESCRIPTION
- Adding Expectation 3 and changing passed example 2 to close #1400- elements with a form owner that has `autocomplete="off"` satisfy the rule/ sc1.3.5.
- The first part of the assumptions section closes #487-  mentions that the form elements collect information about the user and not anyone else. 
- The last paragraph of the assumptions section closes #992- elements with `aria-disabled` are assumed to be out of the sequential focus navigation and not to be otherwise operable.

Not sure if those changes fit the writing style- especially Expectation 3. Please review.

Also, I added changes made in #1415 so it may look like a lot now but should be easier to follow once #1415 passes the final call and then is being merged.

Need for Final Call:
1 week