### PR TITLE
Update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,9 +6,10 @@ Closes issue(s):
 
 Need for Final Call:
 << choose one of the following and remove the rest >>
+<< leave the "How to Review and Approve" section in your pull request description >>
 << check https://act-rules.github.io/pages/design/process/#final-call-aka-call-for-consensus-cfc >>
 This can be merged with 1 approval << choose reason: editorial changes to website/test code, adding new contributor, other (explain). >>
-This will not require a Final Call << choose reason(s): editorial changes, changes to assumptions, background, accessibility support, change to website/test code (not rule), other (explain). >>
+This will not require a Final Call << choose reason(s): editorial changes (including to the applicability, expectation or examples section), changes to assumptions, background, accessibility support, change to website/test code (not rule), other (explain). >>
 This will require a 1 week Final Call << small changes affecting a small number of test cases, if in doubt do not use this. >>
 This will require a 2 weeks Final Call << new rule, or substantial changes affecting a large number of test cases, if in doubt, use this. >>
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,6 @@ Closes issue(s):
 
 Need for Final Call:
 << choose one of the following and remove the rest >>
-<< leave the "How to Review and Approve" section in your pull request description >>
 << check https://act-rules.github.io/pages/design/process/#final-call-aka-call-for-consensus-cfc >>
 This can be merged with 1 approval << choose reason: editorial changes to website/test code, adding new contributor, other (explain). >>
 This will not require a Final Call << choose reason(s): editorial changes (including to the applicability, expectation or examples section), changes to assumptions, background, accessibility support, change to website/test code (not rule), other (explain). >>
@@ -20,6 +19,7 @@ This will require a 2 weeks Final Call << new rule, or substantial changes affec
 ### **When creating PR:**
 
 - [ ] Make sure you're requesting to **pull a branch** (right side) to the `develop` branch (left side).
+- [ ] Make sure you do not remove the "How to Review and Approve" section in your pull request description
 
 ### **After creating PR:**
 

--- a/pages/design/process.md
+++ b/pages/design/process.md
@@ -159,7 +159,7 @@ This includes, but might not be limited to changes that changes, extends or limi
 
 These changes are considered non-substantial and will not require a "Final call" before being published:
 
-- Editorial changes, that does not change the meaning of a rule (also if it's in the Applicability, Expectations or Examples)
+- Editorial changes, that do not change the meaning of a rule (also if it's in the Applicability, Expectations or Examples)
 - Changes to the Assumptions, Background, Accessibility Support. If changes to these sections seem to impact the possible outcomes of a rule, probably these sections have been misused.
 
 ### Passes this stage when:

--- a/pages/design/process.md
+++ b/pages/design/process.md
@@ -159,7 +159,7 @@ This includes, but might not be limited to changes that changes, extends or limi
 
 These changes are considered non-substantial and will not require a "Final call" before being published:
 
-- Editorial changes, that does not change the meaning of a rule (also if it's in the Applicability or Expectations)
+- Editorial changes, that does not change the meaning of a rule (also if it's in the Applicability, Expectations or Examples)
 - Changes to the Assumptions, Background, Accessibility Support. If changes to these sections seem to impact the possible outcomes of a rule, probably these sections have been misused.
 
 ### Passes this stage when:


### PR DESCRIPTION
Update the PR template so that it's clear that editorial changes to the applicability, expectation or example sections do not require a Final Call period. Also, add a request for PR authors to leave the "How to Review and Approve" section in their PR description.

Closes issue(s):

- closes #1468 

Need for Final Call:
This will not require a Final Call 
---

## Pull Request Etiquette

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Final Call period. In case of disagreement, the longer period wins.
