### PR TITLE
form-control-label-descriptive: rename control to field

### DIFF
--- a/_rules/form-field-label-descriptive-cc0f0a.md
+++ b/_rules/form-field-label-descriptive-cc0f0a.md
@@ -1,6 +1,6 @@
 ---
 id: cc0f0a
-name: Form control label is descriptive
+name: Form field label is descriptive
 rule_type: atomic
 description: |
   This rule checks that labels describe the purpose of form field elements.


### PR DESCRIPTION
This is in sync with the [Form field has non-empty accessible name](https://act-rules.github.io/rules/e086e5) rule, where this same change was made.

Need for Final Call: none

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Final Call period. In case of disagreement, the longer period wins.
