### PR TITLE
Add assumption about disabled events

### DIFF
--- a/_rules/device-motion-disabled-c249d5.md
+++ b/_rules/device-motion-disabled-c249d5.md
@@ -45,6 +45,7 @@ For each registered [device orientation event][device orientation] or [device mo
 - If there are ways to disable the device motion based functionality that do not require the user to interact with the web page (e.g. a setting at the operating system level), failing this rule might not be a failure of the success criterion.
 - This rule assumes that there are no changes in the content of the [web page][] caused by another [event][]. If this is not the case, changes may be attributed to the wrong [event][] and the rule may fail while [Success Criterion 2.5.4: Motion Actuation][sc2.5.4] is still satisfied.
 - This rule assumes that the changes happen within a 1 minute time span after the [event][] [firing][] and therefore the comparison between the page before and after the [event][] [firing][] can be made at any time after that time span elapses. If there are changes after this time span, they may not be detected as [changes in content][] and the rule may pass but [Success Criterion 2.5.4: Motion Actuation][sc2.5.4] is not satisfied. The arbitrary 1 minute time span, selected so that testing this rule would not be impractical, is not included in WCAG.
+- After being disabled, the event remains disabled until being re-enabled again. If the event is re-enabled through other non-user controlled means (e.g. a timeout) then this rule may pass while [Success Criterion 2.5.4: Motion Actuation][sc2.5.4] is not satisfied.
 
 ## Accessibility Support
 

--- a/_rules/printable-characters-shortcut-ffbc54.md
+++ b/_rules/printable-characters-shortcut-ffbc54.md
@@ -36,6 +36,7 @@ For each test target at least one of the following is true:
 ## Assumptions
 
 - If there are ways to disable the result of [keyboard events][keyboard event] that do not require the user to interact with the web page (e.g. a setting at the operating system level), failing this rule might not be a failure of the success criterion.
+- After being disabled, the event remains disabled until being re-enabled again. If the event is re-enabled through other non-user controlled means (e.g. a timeout) then this rule may pass while [Success Criterion 2.1.4: Character Key Shortcuts][sc2.1.4] is not satisfied.
 
 ## Accessibility Support
 
@@ -43,7 +44,7 @@ Currently [keyboard events][keyboard event] only support the types `keydown` and
 
 ## Background
 
-- [Understanding Success Criterion 2.1.4: Character Key Shortcuts](https://www.w3.org/WAI/WCAG21/Understanding/character-key-shortcuts.html)
+- [Understanding Success Criterion 2.1.4: Character Key Shortcuts][sc2.1.4]
 - [G217 Providing a mechanism to allow users to remap or turn off character key shortcuts](https://www.w3.org/WAI/WCAG21/Techniques/general/G217)
 - [F99 Failure of Success Criterion 2.1.4 due to implementing character key shortcuts that cannot be turned off or remapped](https://www.w3.org/WAI/WCAG21/Techniques/failures/F99)
 
@@ -355,18 +356,19 @@ This [HTML document][] has a [keyboard event][] [dispatched][] to an [event targ
 </html>
 ```
 
-[html document]: https://dom.spec.whatwg.org/#concept-document
-[focus]: https://html.spec.whatwg.org/#focusable-area
-[event target]: https://dom.spec.whatwg.org/#eventtarget
-[keyboard event]: https://www.w3.org/TR/uievents/#events-keyboardevents
-[legacy keyboard events]: https://www.w3.org/TR/uievents/#legacy-keyboardevent-events
-[dispatched]: https://dom.spec.whatwg.org/#dispatching-events
+[blocked event]: #blocked-event 'Definition of blocked event'
 [changes in content]: #changes-in-content 'Definition of changes in content'
 [clearly labeled location]: #clearly-labeled-location 'Definition of clearly labeled location'
+[dispatched]: https://dom.spec.whatwg.org/#dispatching-events
+[event target]: https://dom.spec.whatwg.org/#eventtarget
+[focus]: https://html.spec.whatwg.org/#focusable-area
+[html document]: https://dom.spec.whatwg.org/#concept-document
 [instrument]: #instrument-to-achieve-an-objective 'Definition of instrument to achieve an objective'
-[set of clearly labeled instruments]: #set-of-clearly-labeled-instruments 'Definition of set of clearly labeled instruments'
-[blocked event]: #blocked-event 'Definition of blocked event'
+[keyboard event]: https://www.w3.org/TR/uievents/#events-keyboardevents
+[legacy keyboard events]: https://www.w3.org/TR/uievents/#legacy-keyboardevent-events
 [printable character]: #printable-characters 'Definition of printable characters'
-[valid modifier keys]: https://www.w3.org/TR/uievents-key/#keys-modifier 'Definition of modifier keys'
 [same key events]: #same-key-events 'Definition of same key events'
+[sc2.1.4]: https://www.w3.org/WAI/WCAG21/Understanding/character-key-shortcuts.html
 [semantic role]: #semantic-role 'Definition of Semantic Role'
+[set of clearly labeled instruments]: #set-of-clearly-labeled-instruments 'Definition of set of clearly labeled instruments'
+[valid modifier keys]: https://www.w3.org/TR/uievents-key/#keys-modifier 'Definition of modifier keys'


### PR DESCRIPTION
Add an assumption to rules [No keyboard shortcut uses only printable characters](https://act-rules.github.io/rules/ffbc54) and [Device motion based changes to the content can be disabled](https://act-rules.github.io/rules/c249d5) to account for situations where an event that has been disabled is re-enabled without user intervention.

Closes issue(s):

- closes #1394 

Need for Final Call:
This will not require a Final Call (changes to assumptions)

---

## Pull Request Etiquette

### **When merging a PR:**

- [ ] Close any issue that the PR resolves. This will happen automatically upon merging if the PR was correctly linked to the issue, e.g. by referencing the issue at the top of this comment.

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Final Call period. In case of disagreement, the longer period wins.
