### PR TITLE
new rule: iframe with negative tabindex has no interactive elements

### DIFF
--- a/_rules/iframe-not-focusable-has-no-interactive-content-akn7bn.md
+++ b/_rules/iframe-not-focusable-has-no-interactive-content-akn7bn.md
@@ -30,7 +30,7 @@ This rule applies to any `iframe` element that has a negative number as a `tabin
 
 ## Expectation
 
-None of the test target's [nested browsing context][] includes elements that are [visible][] and part of the [sequential focus navigation][]. An element is "included" in a [nested browsing context][] if its [owner document][] is the [container document][] of the [nested browsing context][].
+For each test target, the [nested browsing context][] does not include elements that are [visible][] and part of the [sequential focus navigation][]. An element is "included" in a [nested browsing context][] if its [owner document][] is the [container document][] of the [nested browsing context][]. 
 
 ## Assumptions
 

--- a/_rules/iframe-not-focusable-has-no-interactive-content-akn7bn.md
+++ b/_rules/iframe-not-focusable-has-no-interactive-content-akn7bn.md
@@ -1,0 +1,102 @@
+---
+id: akn7bn
+name: iframe with negative tabindex has no interactive elements
+rule_type: atomic
+description: |
+  This rule checks that `iframe` elements with a negative `tabindex` attribute value contain no interactive elements.
+accessibility_requirements:
+  wcag20:2.1.1: # Keyboard (A)
+    forConformance: true
+    failed: not satisfied
+    passed: further testing needed
+    inapplicable: further testing needed
+  wcag-technique:G202: # Ensuring keyboard control for all functionality
+    forConformance: false
+    failed: not satisfied
+    passed: further testing needed
+    inapplicable: further testing needed
+input_aspects:
+  - DOM Tree
+  - CSS Styling
+acknowledgments:
+  authors:
+    - Brian Bors
+    - Wilco Fiers
+---
+
+## Applicability
+
+This rule applies to any `iframe` element that has a negative number as a `tabindex` [attribute value][].
+
+## Expectation
+
+None of the test target's [nested browsing context][] includes elements that are [visible][] and part of the [sequential focus navigation][].
+
+## Assumptions
+
+This rule assumes that interactive content inside `iframe` elements are used to provide functionality. If the interactive content does not provide functionality, for example a button that does nothing when clicked, [success criterion 2.1.1][sc211] may be satisfied, even if the rule is failed.
+
+## Accessibility Support
+
+There are no major accessibility support issues known for this rule.
+
+## Background
+
+By setting the `tabindex` [attribute value][] of an `iframe` element to `-1` or some other negative number, it becomes impossible to move the focus into the [browsing context][nested browsing context] of the `iframe` element. Even though its content is still included in the [sequential focus navigation][], there is no way to move the focus to any of the items in the `iframe` using standard keyboard navigation.
+
+- [Understanding Success Criterion 2.1.1: Keyboard](https://www.w3.org/WAI/WCAG21/Understanding/keyboard)
+- [WCAG Technique G202: Ensuring keyboard control for all functionality](https://www.w3.org/WAI/WCAG21/Techniques/general/G202)
+
+## Test Cases
+
+### Passed
+
+#### Passed Example 1
+
+This `iframe` element contains no content that is part of [sequential focus navigation][].
+
+```html
+<iframe tabindex="-1" srcdoc="<h1>Hello world</h1>"></iframe>
+```
+
+#### Passed Example 2
+
+This `iframe` element contains a link that, because of its `tabindex` is not part of [sequential focus navigation][].
+
+```html
+<iframe tabindex="-1" srcdoc="<a href='/' tabindex='-1'>Home</a>"></iframe>
+```
+
+#### Passed Example 3
+
+This `iframe` element contains no [visible][] content because of the small size of the iframe.
+
+```html
+<iframe tabindex="-1" width="1" height="1" srcdoc="<a href='/'>Home</a>"></iframe>
+```
+
+### Failed
+
+#### Failed Example 1
+
+This `iframe` element has a link that is part of [sequential focus navigation][].
+
+```html
+<iframe tabindex="-1" srcdoc="<a href='/'>Home</a>"></iframe>
+```
+
+### Inapplicable
+
+#### Inapplicable Example 1
+
+This `iframe` element does not have a `tabindex` [attribute value][] that is a negative number
+
+```html
+<iframe tabindex="0" srcdoc="<a href='/'>Home</a>"></iframe>
+```
+
+[attribute value]: #attribute-value 'Definition of Attribute Value'
+[visible]: #visible 'Definition of visible'
+[nested browsing context]: https://html.spec.whatwg.org/#nested-browsing-context 'HTML nested browsing context, 2020/12/04'
+[sequential focus navigation]: https://html.spec.whatwg.org/#sequential-focus-navigation 'HTML sequential focus navigation, 2020/12/04'
+[sc211]: https://www.w3.org/TR/WCAG21/#keyboard 'WCAG 2.1 Success criterion 2.1.1 Keyboard'

--- a/_rules/iframe-not-focusable-has-no-interactive-content-akn7bn.md
+++ b/_rules/iframe-not-focusable-has-no-interactive-content-akn7bn.md
@@ -30,7 +30,7 @@ This rule applies to any `iframe` element that has a negative number as a `tabin
 
 ## Expectation
 
-None of the test target's [nested browsing context][] includes elements that are [visible][] and part of the [sequential focus navigation][].
+None of the test target's [nested browsing context][] includes elements that are [visible][] and part of the [sequential focus navigation][]. An element is "included" if its [owner document][] is the [container document][] of the [nested browsing context][].
 
 ## Assumptions
 
@@ -96,7 +96,9 @@ This `iframe` element does not have a `tabindex` [attribute value][] that is a n
 ```
 
 [attribute value]: #attribute-value 'Definition of Attribute Value'
-[visible]: #visible 'Definition of visible'
-[nested browsing context]: https://html.spec.whatwg.org/#nested-browsing-context 'HTML nested browsing context, 2020/12/04'
-[sequential focus navigation]: https://html.spec.whatwg.org/#sequential-focus-navigation 'HTML sequential focus navigation, 2020/12/04'
+[container document]: https://html.spec.whatwg.org/#bc-container-document 'HTML browsing context container document, 2020/12/18'
+[nested browsing context]: https://html.spec.whatwg.org/#nested-browsing-context 'HTML nested browsing context, 2020/12/18'
+[owner document]: https://dom.spec.whatwg.org/#dom-node-ownerdocument 'DOM node owner document property, 2020/12/18'
 [sc211]: https://www.w3.org/TR/WCAG21/#keyboard 'WCAG 2.1 Success criterion 2.1.1 Keyboard'
+[sequential focus navigation]: https://html.spec.whatwg.org/#sequential-focus-navigation 'HTML sequential focus navigation, 2020/12/18'
+[visible]: #visible 'Definition of visible'

--- a/_rules/iframe-not-focusable-has-no-interactive-content-akn7bn.md
+++ b/_rules/iframe-not-focusable-has-no-interactive-content-akn7bn.md
@@ -30,7 +30,7 @@ This rule applies to any `iframe` element that has a negative number as a `tabin
 
 ## Expectation
 
-None of the test target's [nested browsing context][] includes elements that are [visible][] and part of the [sequential focus navigation][]. An element is "included" if its [owner document][] is the [container document][] of the [nested browsing context][].
+None of the test target's [nested browsing context][] includes elements that are [visible][] and part of the [sequential focus navigation][]. An element is "included" in a [nested browsing context][] if its [owner document][] is the [container document][] of the [nested browsing context][].
 
 ## Assumptions
 

--- a/_rules/iframe-not-focusable-has-no-interactive-content-akn7bn.md
+++ b/_rules/iframe-not-focusable-has-no-interactive-content-akn7bn.md
@@ -34,7 +34,7 @@ For each test target, the [nested browsing context][] does not include elements 
 
 ## Assumptions
 
-This rule assumes that interactive content inside `iframe` elements are used to provide functionality. If the interactive content does not provide functionality, for example a button that does nothing when clicked, [success criterion 2.1.1][sc211] may be satisfied, even if the rule is failed.
+This rule assumes that interactive content inside `iframe` elements is used to provide functionality. If the interactive content does not provide functionality, for example a button that does nothing when clicked, [success criterion 2.1.1][sc211] may be satisfied, even if the rule is failed.
 
 ## Accessibility Support
 


### PR DESCRIPTION
  This rule checks that `iframe` elements with a negative `tabindex` attribute value contain no interactive elements.

Need for Final Call: 2 weeks
## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Final Call period. In case of disagreement, the longer period wins.
