### PR TITLE
Take out unnecessary condition from hidden-state definition

### DIFF
--- a/pages/glossary/hidden-state.md
+++ b/pages/glossary/hidden-state.md
@@ -10,7 +10,6 @@ input_aspects:
 
 An HTML element's _hidden state_ is "true" if at least one of the following is true for itself or any of its [ancestors][] in the [flat tree][]:
 
-- has a `hidden` attribute; or
 - has a [computed][] CSS property `display` of `none`; or
 - has a [computed][] CSS property `visibility` of `hidden`; or
 - has an `aria-hidden` attribute set to `true`


### PR DESCRIPTION
The "hidden" attribute gives an element the display:none style, so calling it out as a separate condition is unnecessary.

Need for Final Call: none, editorial

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Final Call period. In case of disagreement, the longer period wins.
