### PR TITLE
fix URL in meta-refresh rules

### DIFF
--- a/_rules/meta-refresh-no-delay-bc659a.md
+++ b/_rules/meta-refresh-no-delay-bc659a.md
@@ -95,8 +95,8 @@ First valid `<meta http-equiv="refresh">` redirects immediately.
 
 ```html
 <head>
-	<meta http-equiv="refresh" content="0; https://w3c.org" />
-	<meta http-equiv="refresh" content="5; https://w3c.org" />
+	<meta http-equiv="refresh" content="0; https://w3.org" />
+	<meta http-equiv="refresh" content="5; https://w3.org" />
 </head>
 ```
 
@@ -106,7 +106,7 @@ Redirects after more than 20 hours.
 
 ```html
 <head>
-	<meta http-equiv="refresh" content="72001; https://w3c.org" />
+	<meta http-equiv="refresh" content="72001; https://w3.org" />
 </head>
 ```
 
@@ -128,7 +128,7 @@ Redirects after 30 seconds.
 
 ```html
 <head>
-	<meta http-equiv="refresh" content="30; URL='https://w3c.org'" />
+	<meta http-equiv="refresh" content="30; URL='https://w3.org'" />
 </head>
 ```
 
@@ -138,8 +138,8 @@ First `<meta http-equiv="refresh">` element is not valid, second one redirects a
 
 ```html
 <head>
-	<meta http-equiv="refresh" content="0: https://w3c.org" />
-	<meta http-equiv="refresh" content="5; https://w3c.org" />
+	<meta http-equiv="refresh" content="0: https://w3.org" />
+	<meta http-equiv="refresh" content="5; https://w3.org" />
 </head>
 ```
 
@@ -149,7 +149,7 @@ Redirects after exactly 20 hours.
 
 ```html
 <head>
-	<meta http-equiv="refresh" content="72000; https://w3c.org" />
+	<meta http-equiv="refresh" content="72000; https://w3.org" />
 </head>
 ```
 
@@ -181,7 +181,7 @@ No `http-equiv="refresh"` attribute.
 
 ```html
 <head>
-	<meta http-equiv="refresh" content="0: https://w3c.org" />
+	<meta http-equiv="refresh" content="0: https://w3.org" />
 </head>
 ```
 
@@ -221,7 +221,7 @@ No `http-equiv="refresh"` attribute.
 
 ```html
 <head>
-	<meta http-equiv="refresh" content="+5; https://w3c.org" />
+	<meta http-equiv="refresh" content="+5; https://w3.org" />
 </head>
 ```
 
@@ -231,7 +231,7 @@ No `http-equiv="refresh"` attribute.
 
 ```html
 <head>
-	<meta http-equiv="refresh" content="foo; URL='https://w3c.org'" />
+	<meta http-equiv="refresh" content="foo; URL='https://w3.org'" />
 </head>
 ```
 

--- a/_rules/meta-refresh-no-delay-no-exception-bisz58.md
+++ b/_rules/meta-refresh-no-delay-no-exception-bisz58.md
@@ -75,7 +75,7 @@ This `meta` element redirects the user immediately. Users won't notice the chang
 
 ```html
 <head>
-	<meta http-equiv="refresh" content="0; URL='https://w3c.org'" />
+	<meta http-equiv="refresh" content="0; URL='https://w3.org'" />
 </head>
 ```
 
@@ -85,8 +85,8 @@ The first valid `meta` element redirects immediately.
 
 ```html
 <head>
-	<meta http-equiv="refresh" content="0; https://w3c.org" />
-	<meta http-equiv="refresh" content="5; https://w3c.org" />
+	<meta http-equiv="refresh" content="0; https://w3.org" />
+	<meta http-equiv="refresh" content="5; https://w3.org" />
 </head>
 ```
 
@@ -108,7 +108,7 @@ This `meta` element redirects the user after 30 seconds.
 
 ```html
 <head>
-	<meta http-equiv="refresh" content="30; URL='https://w3c.org'" />
+	<meta http-equiv="refresh" content="30; URL='https://w3.org'" />
 </head>
 ```
 
@@ -118,8 +118,8 @@ The first `meta` element is not valid (because of the colon instead of a semi-co
 
 ```html
 <head>
-	<meta http-equiv="refresh" content="0: https://w3c.org" />
-	<meta http-equiv="refresh" content="5; https://w3c.org" />
+	<meta http-equiv="refresh" content="0: https://w3.org" />
+	<meta http-equiv="refresh" content="5; https://w3.org" />
 </head>
 ```
 
@@ -201,7 +201,7 @@ This `meta` element has an invalid `content` attribute, and is therefore inappli
 
 ```html
 <head>
-	<meta http-equiv="refresh" content="+5; http://w3c.org" />
+	<meta http-equiv="refresh" content="+5; http://w3.org" />
 </head>
 ```
 
@@ -211,7 +211,7 @@ This `meta` element has an invalid `content` attribute, and is therefore inappli
 
 ```html
 <head>
-	<meta http-equiv="refresh" content="foo; URL='https://w3c.org'" />
+	<meta http-equiv="refresh" content="foo; URL='https://w3.org'" />
 </head>
 ```
 


### PR DESCRIPTION
w3c.org does not exists, and instead redirects to w3.org. Think we all know this was a mistake, not sure how this got overlooked in reviews though.

Closes #1543

Need for Final Call: **none**, fix is urgent and inconsequential to the rule's intent.

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Final Call period. In case of disagreement, the longer period wins.
