### PR TITLE
Editorial fixes that `lang` of elements- de46e4

### DIFF
--- a/_rules/element-lang-valid-de46e4.md
+++ b/_rules/element-lang-valid-de46e4.md
@@ -29,9 +29,9 @@ acknowledgments:
 
 This rules applies to any HTML element with a `lang` [attribute value][] that is not empty (`""`) and for which all of the following is true:
 
-- the element is a [descendant][] in the [flat tree][] of a `body` element; and
-- the element has a [node document][] with a [content type][] of `text/html`; and
-- the element has a [text node][] as a [descendant][] in the [flat tree][] that is [visible][] or [included in the accessibility tree][].
+- **descendant**: the element is a [descendant][] in the [flat tree][] of a `body` element; and
+- **content type**: the element has an associated [node document][] with a [content type][] of `text/html`; and
+- **visible or included in the accessibility tree**: the element has a [text node][] as a [descendant][] in the [flat tree][] that is [visible][] or [included in the accessibility tree][].
 
 ## Expectation
 

--- a/_rules/element-lang-valid-de46e4.md
+++ b/_rules/element-lang-valid-de46e4.md
@@ -31,7 +31,7 @@ This rules applies to any HTML element with a `lang` [attribute value][] that is
 
 - **descendant**: the element is a [descendant][] in the [flat tree][] of a `body` element; and
 - **content type**: the element has an associated [node document][] with a [content type][] of `text/html`; and
-- **visible or included in the accessibility tree**: the element has a [text node][] as a [descendant][] in the [flat tree][] that is [visible][] or [included in the accessibility tree][].
+- **available**: the element has a [text node][] as a [descendant][] in the [flat tree][] that is [visible][] or [included in the accessibility tree][].
 
 ## Expectation
 


### PR DESCRIPTION
Minor editorial fixes to the applicability section of [Element with `lang` attribute has valid language tag](https://act-rules.github.io/rules/de46e4).

Updating listed conditions.

No need for the final call.

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Final Call period. In case of disagreement, the longer period wins.
