### PR TITLE
Minor editorial fix to video element visual-only content has transcript [ee13b5]

### DIFF
--- a/_rules/video-only-transcript-ee13b5.md
+++ b/_rules/video-only-transcript-ee13b5.md
@@ -64,7 +64,7 @@ This `video` element, which has no audio, has a text transcript available on the
   <source src="/test-assets/rabbit-video/silent.webm" type="video/webm"></source>
 </video>
 <p>The above video shows a giant fat rabbit climbing out of a hole in the ground.
-He stretches, yaws, and then starts walking.
+He stretches, yawns, and then starts walking.
 Then he stops to scratch his bottom.</p>
 </html>
 ```
@@ -96,7 +96,7 @@ This `video` element, which has no audio, has an incorrect text transcript avail
   <source src="/test-assets/rabbit-video/silent.webm" type="video/webm"></source>
 </video>
 <p>The above video shows a giant fat dog climbing out of a hole in the ground.
-He stretches, yaws, and then starts walking.
+He stretches, yawns, and then starts walking.
 Then he stops to scratch his bottom.</p>
 </html>
 ```
@@ -126,7 +126,7 @@ This `video` element, which has no audio, has a text transcript available on the
   <source src="/test-assets/rabbit-video/silent.webm" type="video/webm"></source>
 </video>
 <p style="text-indent: -9999px;">The above video shows a giant fat rabbit climbing out of a hole in the ground.
-He stretches, yaws, and then starts walking.
+He stretches, yawns, and then starts walking.
 Then he stops to scratch his bottom.</p>
 </html>
 ```
@@ -142,7 +142,7 @@ This `video` element, which has no audio, has a text transcript available on the
   <source src="/test-assets/rabbit-video/silent.webm" type="video/webm"></source>
 </video>
 <p aria-hidden="true">The above video shows a giant fat rabbit climbing out of a hole in the ground.
-He stretches, yaws, and then starts walking.
+He stretches, yawns, and then starts walking.
 Then he stops to scratch his bottom.</p>
 </html>
 ```

--- a/test-assets/rabbit-video/incorrect-transcript.html
+++ b/test-assets/rabbit-video/incorrect-transcript.html
@@ -7,8 +7,8 @@
 	<body>
 		<h1>Description of the dog video</h1>
 		<p>
-			The video shows a giant fat dog climbing out of a hole in the ground. He stretches, yaws, and then starts walking.
-			Then he stops to scratch his bottom.
+			The video shows a giant fat dog climbing out of a hole in the ground. He stretches, yawns, and then starts
+			walking. Then he stops to scratch his bottom.
 		</p>
 	</body>
 </html>

--- a/test-assets/rabbit-video/transcript.html
+++ b/test-assets/rabbit-video/transcript.html
@@ -7,7 +7,7 @@
 	<body>
 		<h1>Description of the rabbit video</h1>
 		<p>
-			The video shows a giant fat rabbit climbing out of a hole in the ground. He stretches, yaws, and then starts
+			The video shows a giant fat rabbit climbing out of a hole in the ground. He stretches, yawns, and then starts
 			walking. Then he stops to scratch his bottom.
 		</p>
 	</body>


### PR DESCRIPTION
Did not manage to commit suggestions made by @tbostic32 in #1635 before it got merged. Doing it in this PR. Rule [video element visual-only content has transcript](https://act-rules.github.io/rules/ee13b5).

Need for Final Call: no need for the final call.

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Final Call period. In case of disagreement, the longer period wins.
