### PR TITLE
Clarify 'one of the following' phrases

### DIFF
--- a/_rules/aria-required-owned-element-bc4a75.md
+++ b/_rules/aria-required-owned-element-bc4a75.md
@@ -24,7 +24,7 @@ acknowledgments:
 
 ## Applicability
 
-This rule applies to any HTML or SVG element that is [included in the accessibility tree][] and has a [WAI-ARIA 1.1][] [explicit semantic role][] with [required owned elements][], except if one of the following is true:
+This rule applies to any HTML or SVG element that is [included in the accessibility tree][] and has a [WAI-ARIA 1.1][] [explicit semantic role][] with [required owned elements][], except if one or more of the following is true:
 
 - the element has a [semantic role][] of `combobox`; or
 - the element has the `aria-busy` [attribute value][] of `true`, or has an [ancestor][] in the accessibility tree with this [attribute value][].

--- a/_rules/auto-update-text-efbfc7.md
+++ b/_rules/auto-update-text-efbfc7.md
@@ -34,7 +34,7 @@ This rule applies to any [HTML element][] that has a [visible][] [text node][] a
 
 ## Expectation
 
-For each test target there is at least one set of [instruments][instrument], where each [instrument][] is in the same [web page][] as the test target or can be found in a [clearly labeled location][] from that [web page][], to achieve one of the following objectives:
+For each test target there is at least one set of [instruments][instrument], where each [instrument][] is in the same [web page][] as the test target or can be found in a [clearly labeled location][] from that [web page][], to achieve at least one of the following objectives:
 
 - pause and resume the change of the [visible text content][]; or
 - stop the change of the [visible text content][]; or

--- a/_rules/autocomplete-valid-value-73f2c2.md
+++ b/_rules/autocomplete-valid-value-73f2c2.md
@@ -21,7 +21,7 @@ acknowledgments:
 
 ## Applicability
 
-This rule applies to any HTML `input`, `select` and `textarea` element with an `autocomplete` [attribute value][] that is neither empty (`""`) nor only [ASCII whitespace][], except if one of the following is true:
+This rule applies to any HTML `input`, `select` and `textarea` element with an `autocomplete` [attribute value][] that is neither empty (`""`) nor only [ASCII whitespace][], except if one or more of the following is true:
 
 - **toggle**: the `autocomplete` attribute consists of a single token that is an [ASCII case-insensitive][] match for the string `off` or the string `on`; or
 - **disabled**: the element is a [disabled element]; or

--- a/_rules/device-motion-disabled-c249d5.md
+++ b/_rules/device-motion-disabled-c249d5.md
@@ -30,7 +30,7 @@ This rule applies to an [HTML document][] with an associated [Window object][] t
 
 ## Expectation
 
-For each registered [device orientation event][device orientation] or [device motion event][device motion] in the test target one of the following is true:
+For each registered [device orientation event][device orientation] or [device motion event][device motion] in the test target at least one of the following is true:
 
 - **no changes:** The registered event does not cause [changes to the content][changes in content] of the [web page][] within a 1 minute time span of the [event firing][event firing]; or
 - **disabled:** There is at least one [set of clearly labeled instruments][] to [block the event][blocked event][] for at least 1 minute.

--- a/_rules/device-motion-user-interface-7677a9.md
+++ b/_rules/device-motion-user-interface-7677a9.md
@@ -30,7 +30,7 @@ This rule applies to any [HTML document][] with an associated [Window object][] 
 
 ## Expectation
 
-For each registered [device orientation event][device orientation] or [device motion event][device motion] in the test target one of the following is true:
+For each registered [device orientation event][device orientation] or [device motion event][device motion] in the test target at least one of the following is true:
 
 - **no changes:** The registered event does not cause [changes to the content][changes in content] of the [web page][]; or
 - **same result:** There is at least one set of [instruments][instrument], where each [instrument][] is in the same [web page][] of the registered event or can be found in a [clearly labeled location][] from that [web page][], causing the same [changes in content][] as the event.

--- a/_rules/focusable-no-keyboard-trap-80af7b.md
+++ b/_rules/focusable-no-keyboard-trap-80af7b.md
@@ -39,7 +39,7 @@ This rule only applies to any HTML or SVG element that is [focusable][].
 
 ## Expectation
 
-For each test target, the [outcome](#outcome) of one of the following rules is "passed":
+For each test target, the [outcome](#outcome) of at least one of the following rules is "passed":
 
 - [Focusable Element Has No Keyboard Trap Via Standard Navigation](https://act-rules.github.io/rules/a1b64e)
 - [Focusable Element Has No Keyboard Trap Via Non-Standard Navigation](https://act-rules.github.io/rules/ebe86a)

--- a/_rules/image-accessible-name-descriptive-qt1vmo.md
+++ b/_rules/image-accessible-name-descriptive-qt1vmo.md
@@ -41,7 +41,7 @@ htmlHintIgnore:
 
 ## Applicability
 
-This rule applies to any `img`, `canvas` or `svg` element that is [visible][] and has a non-empty [accessible name][], except if one of the following is true:
+This rule applies to any `img`, `canvas` or `svg` element that is [visible][] and has a non-empty [accessible name][], except if one or more of the following is true:
 
 - The element has an [ancestor][] in the [flat tree][] that is [named from author][]; or
 - The element is an `img` element where the [current request][]'s [state][image request state] is not [completely available][].

--- a/_rules/image-not-in-acc-tree-is-decorative-e88epe.md
+++ b/_rules/image-not-in-acc-tree-is-decorative-e88epe.md
@@ -30,13 +30,13 @@ htmlHintIgnore:
 
 ## Applicability
 
-This rule applies to any `img`, `canvas` or `svg` element that is [visible][] and for which one of the following is true:
+This rule applies to any `img`, `canvas` or `svg` element that is [visible][] and for which at least one of the following is true:
 
 - **excluded**: The element is not [included in the accessibility tree][]; or
 - **ignored svg**: The element is an `svg` with an empty (`""`) [accessible name][] and a [semantic role][] of `graphics-document`; or
 - **ignored canvas**: The element is a `canvas` with an empty (`""`) [accessible name][] and no [explicit semantic role][]; or
 
-**Exception**: This rule never applies to elements for which one of the following is true:
+**Exception**: This rule never applies to elements for which one or more of the following is true:
 
 - The element has an [ancestor][] in the [flat tree][] that is [named from author][]; or
 - The element is an `img` element where the [current request][]'s [state][image request state] is not [completely available][].

--- a/_rules/letter-spacing-not-important-24afc2.md
+++ b/_rules/letter-spacing-not-important-24afc2.md
@@ -25,7 +25,7 @@ This rule applies to any HTML element that is [visible][] and for which the `sty
 
 ## Expectation
 
-For each test target, one of the following is true:
+For each test target, at least one of the following is true:
 
 - **not important**: the [computed][] value of its [letter-spacing][] property is not [important][]; or
 - **wide enough**: the [computed][] value of its [letter-spacing][] property is at least 0.12 times the [computed][] value of its [font-size][] property; or

--- a/_rules/line-height-not-important-78fd32.md
+++ b/_rules/line-height-not-important-78fd32.md
@@ -25,7 +25,7 @@ This rule applies to any HTML element that is [visible][] and for which the `sty
 
 ## Expectation
 
-For each test target, one of the following is true:
+For each test target, at least one of the following is true:
 
 - **not important**: the [computed][] value of its [line-height][] property is not [important][]; or
 - **large enough**: the [computed][] value of its [line-height][] property is not `normal`, and is at least `1.5` or 1.5 times the [computed][] value of its [font-size][] property; or

--- a/_rules/scrollable-element-keyboard-accessible-0ssw9k.md
+++ b/_rules/scrollable-element-keyboard-accessible-0ssw9k.md
@@ -30,7 +30,7 @@ acknowledgments:
 
 ## Applicability
 
-This rule applies to any HTML element that has [visible][] [children][] in the [flat tree][] for which one of the following is true:
+This rule applies to any HTML element that has [visible][] [children][] in the [flat tree][] for which at least one of the following is true:
 
 - It has a [horizontal scroll distance][scrollable] greater than the [computed][] [left][padding-left] or [right padding][padding-right] of the element; or
 - It has a [vertical scroll distance][scrollable] greater than the [computed][] [top][padding-top] or [bottom padding][padding-bottom] of the element

--- a/_rules/text-contrast-afw4f7.md
+++ b/_rules/text-contrast-afw4f7.md
@@ -28,7 +28,7 @@ acknowledgments:
 
 ## Applicability
 
-This rule applies to any [visible][] character in a [text node][] that is a [child][] in the [flat tree][] of an HTML element, except if the [text node][] has an [ancestor][] in the [flat tree][] for which one of the following is true:
+This rule applies to any [visible][] character in a [text node][] that is a [child][] in the [flat tree][] of an HTML element, except if the [text node][] has an [ancestor][] in the [flat tree][] for which at least one of the following is true:
 
 - **widget**: the ancestor is a [semantic widget][]; or
 - **disabled label**: the ancestor is used in the [accessible name][] of a [semantic widget][] that is [disabled][]; or

--- a/_rules/text-contrast-enhanced-09o5cg.md
+++ b/_rules/text-contrast-enhanced-09o5cg.md
@@ -32,7 +32,7 @@ acknowledgments:
 
 ## Applicability
 
-This rule applies to any [visible][] character in a [text node][] that is a [child][] in the [flat tree][] of an HTML element, except if the [text node][] has an [ancestor][] in the [flat tree][] for which one of the following is true:
+This rule applies to any [visible][] character in a [text node][] that is a [child][] in the [flat tree][] of an HTML element, except if the [text node][] has an [ancestor][] in the [flat tree][] for which at least one of the following is true:
 
 - **widget**: the ancestor is a [semantic widget][]; or
 - **disabled label**: the ancestor is used in the [accessible name][] of a [semantic widget][] that is [disabled][]; or

--- a/_rules/word-spacing-not-important-9e45ec.md
+++ b/_rules/word-spacing-not-important-9e45ec.md
@@ -25,7 +25,7 @@ This rule applies to any HTML element that is [visible][] and for which the `sty
 
 ## Expectation
 
-For each test target, one of the following is true:
+For each test target, at least one of the following is true:
 
 - **not important**: the [computed][] value of its [word-spacing][] property is not [important][]; or
 - **wide enough**: the [computed][] value of its [word-spacing][] property is at least 0.16 times the [computed][] value of its [font-size][] property; or

--- a/_rules/zoom-text-no-overflow-clipping-59br37.md
+++ b/_rules/zoom-text-no-overflow-clipping-59br37.md
@@ -33,7 +33,7 @@ This rule applies to any [text node][] for which all of the following is true wh
 
 ## Expectation
 
-Each test target is not [clipped by overflow][clipped] of an [ancestor][] in the [flat tree][] when in a [viewport size][] of 640 by 512, except if the [clipping][clipped] [ancestor][] has one of the following:
+Each test target is not [clipped by overflow][clipped] of an [ancestor][] in the [flat tree][] when in a [viewport size][] of 640 by 512, except if the [clipping][clipped] [ancestor][] has at least one of the following:
 
 - **text-overflow**: A [computed][] [white-space][] of `nowrap`, and a [computed][] [text-overflow][] that is not `clip`; or
 

--- a/pages/design/rule-design.md
+++ b/pages/design/rule-design.md
@@ -163,7 +163,7 @@ Applicability and expectations, often have multiple conditions that need to be m
 
 This phrasing is designed to be easily readable, but may not work in every situation. In all cases prefer readability over prescriptive formatting. Additionally to this, keep the following in mind when listing conditions:
 
-- The phrasing "for which (all | one of) the following is" can be modified based on use, such as "to achieve one of the following objectives".
+- The phrasing "for which (all | at least one of) the following is" can be modified based on use, such as "to achieve at least one of the following objectives".
 - Labels are optional, not recommended for lists of 2, and recommended for lists of 4 or more conditions. Keep the labels short, 1 or 2 words. If the label does not help clarify the list, don't use them even for longer lists (for example when the condition is short and the label would just repeat it). If you use labels, all items in the list need to have a label.
 - The subject must be referenced in some way in each conditional. For example by starting with "the element has", or by using phrasing like "The innerText of the element has...". The subject must be a single word that is referenced in the phrase preceding the conditional list. Exception: When using element or attribute names, include what it is in the referenced, e.g. "`img` element".
 - Tend towards using a list if there are more than three conditions. Keep the most important condition(s) in the phrase, not in the list. For example, if something is about `img` elements, use "Each `img` element for which all the following is true, instead of putting "`img` element" in the condition list itself.

--- a/pages/glossary/disabled-element.md
+++ b/pages/glossary/disabled-element.md
@@ -7,7 +7,7 @@ input_aspects:
   - DOM tree
 ---
 
-An element is _disabled_ when it has been rendered [inoperable][] in one of the following ways:
+An element is _disabled_ when it has been rendered [inoperable][] in one or more of the following ways:
 
 1. The element matches the [`:disabled` pseudo-class][disabled pseudo-class]. For HTML elements this means that the element is [actually disabled][].
 

--- a/pages/glossary/marked-as-decorative.md
+++ b/pages/glossary/marked-as-decorative.md
@@ -7,7 +7,7 @@ input_aspects:
   - DOM tree
 ---
 
-An element is _marked as decorative_ if one of the following conditions is true:
+An element is _marked as decorative_ if one or more of the following conditions is true:
 
 - it has an [explicit role][] of `none` or `presentation`; or
 - it is an `img` element with an `alt` attribute whose value is the empty string (`alt=""`), and with no [explicit role][].

--- a/pages/glossary/programmatically-determined-link-context.md
+++ b/pages/glossary/programmatically-determined-link-context.md
@@ -8,7 +8,7 @@ input_aspects:
   - DOM tree
 ---
 
-The _programmatically determined context_ of a link (or _programmatically determined link context_) is the set of all elements that are [included in the accessibility tree][], and have one of the following relationships to the link:
+The _programmatically determined context_ of a link (or _programmatically determined link context_) is the set of all elements that are [included in the accessibility tree][], and have one or more of the following relationships to the link:
 
 - being an [ancestor][] of the link in the [flat tree][] with a [semantic role][] of `listitem`; or
 - being the closest [ancestor][] of the link in the [flat tree][] that is a `p` element; or

--- a/pages/glossary/text-inheriting-language.md
+++ b/pages/glossary/text-inheriting-language.md
@@ -15,7 +15,7 @@ The _text inheriting its programmatic language_ from an element E is composed of
 - **accessible text**: the [accessible name][] and [accessible description][] of any element inheriting its programmatic language from E, and [included in the accessibility tree][];
 - **page title**: the value of the [document title][], only if E is a [document][] in a [top-level browsing context][].
 
-An element F is an _element inheriting its programmatic language_ from an element E if one of the following conditions is true (recursively):
+An element F is an _element inheriting its programmatic language_ from an element E if at least one of the following conditions is true (recursively):
 
 - F is E itself (an element always inherits its programmatic language from itself); or
 - F does not have a non-empty `lang` attribute, and is the child in the [flat tree][] of an element inheriting its programmatic language from E; or


### PR DESCRIPTION
I used "at least one of the following" in phrases where the outcome is something desirable. It seemed a little odd to say "except if at least one... " so I used "one ore more" in a few cases where "at least" seemed out of place.

- closes #1624

Need for Final Call: 2 weeks. This change touches a large number of rules.

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Final Call period. In case of disagreement, the longer period wins.
