### PR TITLE
Correctly handle visibility in Hidden State

### DIFF
--- a/pages/glossary/hidden-state.md
+++ b/pages/glossary/hidden-state.md
@@ -8,15 +8,16 @@ input_aspects:
   - DOM tree
 ---
 
-An HTML element's _hidden state_ is "true" if at least one of the following is true for itself or any of its [ancestors][] in the [flat tree][]:
+An HTML element's _hidden state_ is "true" if either it has a [computed][] CSS property `visibility` whose value is not `visible`; or at least one of the following is true for any of its [inclusive ancestors][] in the [flat tree][]:
 
 - has a `hidden` attribute; or
 - has a [computed][] CSS property `display` of `none`; or
-- has a [computed][] CSS property `visibility` of `hidden`; or
 - has an `aria-hidden` attribute set to `true`
 
 In any other case, the element's _hidden state_ is "false".
 
-[ancestors]: https://dom.spec.whatwg.org/#concept-tree-ancestor 'Definition Ancestor'
+> **Note**: Contrarily to the other conditions, the `visibility` CSS property may be reverted by descendants.
+
+[inclusive ancestors]: https://dom.spec.whatwg.org/#concept-tree-inclusive-ancestor 'DOM Definition of Inclusive Ancestor'
 [computed]: https://www.w3.org/TR/css-cascade/#computed-value 'CSS definition of computed value'
 [flat tree]: https://drafts.csswg.org/css-scoping/#flat-tree 'Definition of flat tree'


### PR DESCRIPTION
Update "hidden state" to only look at `visibility` on the element itself, not its ancestors, because `visibility: hidden` can be overwritten by a later `visibility: visible` (opposite to `display: none` or `aria-hidden=true`).

Also rephrase to handle `visibility: collapse`.

Closes issue(s):

- closes #1656 

Need for Final Call:
This will require a 1 week Final Call (small bugfix in a definition)

---

## Pull Request Etiquette

### **When creating PR:**

- [X] Make sure you're requesting to **pull a branch** (right side) to the `develop` branch (left side).
- [X] Make sure you do not remove the "How to Review and Approve" section in your pull request description

### **After creating PR:**

- [X] Add yourself (and co-authors) as "Assignees" for PR.
- [X] Add label to indicate if it's a `Rule`, `Definition` or `Chore`.
- [X] [Link the PR to any issue it solves](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue). This will be done automatically by [referencing the issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) at the top of this comment in the indicated place.
- [X] Optionally request feedback from anyone in particular by assigning them as "Reviewers".

### **When merging a PR:**

- [ ] Close any issue that the PR resolves. This will happen automatically upon merging if the PR was correctly linked to the issue, e.g. by referencing the issue at the top of this comment.

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Final Call period. In case of disagreement, the longer period wins.
