### PR TITLE
Idea: Scope expectations

### DIFF
--- a/_rules/heading-descriptive-b49b2e.md
+++ b/_rules/heading-descriptive-b49b2e.md
@@ -27,6 +27,13 @@ acknowledgments:
 
 This rule applies to any element with the [semantic role][] of heading that is either [visible][] or [included in the accessibility tree][].
 
+## Scope Expectation
+
+The applicability includes each block of text consisting of a single sentence, phrase or word, for which all of the following is true:
+
+- The text is visually presented in a way that can be understood as a heading; and
+- Expectation 1 or expecration 2 is true for the block of text.
+
 ## Expectation 1
 
 Each target element which is [visible][] describes the topic or purpose of the first [palpable content][] which is non-[decorative][], [visible][], and after the target in tree order in the [flat tree][].


### PR DESCRIPTION
This PR is NOT intended to be merged. It is a sketch of an idea I'm hoping to discuss with the groups.

A common theme I see in our rules is that they start with how a thing is marked up, and then we check if that markup is correct. Occasionally, but by no means always do we write a rule to address the counter-part to that; testing that everything that should have that markup actually has.

One way to think of them is in terms of a van diagram. For example; there is a set of everything that is marked up as a heading, and then there is the set of everything that should be marked up as a heading. In an ideal world those are the same, but when they are not, there are two types of issues that come from that. Either something is marked as a heading when it shouldn't be, or something should be marked as a heading but isn't.

ACT rules tend to start with the "What is"-set, and checks it agains the "Ought to be"-set because the applicability has to be objective, and describing the "ought to be"s as objective has proven practically impossible.

One way we might be able to address that problem is by creating a new type of expectation. This PR shows what something like that might look like. This is currently **not allowed by the ACT Rules Format**, but if this proves useful, it might be something we add in a new version. Looking forward to discuss this with the group.


The biggest drawback I see to this is how it sort of breaks the "atomic" requirement of the ACT Rules Format. This adds complexity to the rules format, since there are now two types of expectations, which quite possibly may mean we'll need more types of implementations too.

Other possible solutions could be to either let go of the "Applicability must be objective" requirement, or maybe to change the requirement to allowing a subjective applicability, only if all expectations are objective.
