### PR TITLE
ARIA required owned element, add nested group examples

### DIFF
--- a/_rules/aria-required-owned-element-bc4a75.md
+++ b/_rules/aria-required-owned-element-bc4a75.md
@@ -138,6 +138,23 @@ This element with the `list` role only owns elements with the `listitem` role, o
 </div>
 ```
 
+
+#### Passed Example 7
+
+This element with the `list` role only owns an element with a `group` role. The `group` in turn owns an element with the `listitem` role, and an element with the `group` role, in which each element has the `listitem` role. ARIA `group` roles are allowed to own other elements with a `group` role.
+
+```html
+<div role="list">
+	<div role="group">
+		<span role="listitem">Item 1</span>
+		<div role="group">
+			<span role="listitem">Item 2</span>
+			<span role="listitem">Item 3</span>
+		</div>
+	</div>
+</div>
+```
+
 ### Failed
 
 #### Failed Example 1
@@ -203,6 +220,22 @@ This element with the `list` role owns an element with the `group` role, but the
 	<div role="group">
 		<span role="tab">Item 1</span>
 		<span role="tab">Item 2</span>
+	</div>
+</div>
+```
+
+#### Failed Example 7
+
+This element with the `list` role only owns an element with a `group` role. The `group` in turn owns an element with the `listitem` role, and an element with the `group` role, in which each element has the `tab` role. ARIA `group` roles are allowed to own other elements with a `group` role, but those nested `group` nodes must still meet the requirements.
+
+```html
+<div role="list">
+	<div role="group">
+		<span role="listitem">Item 1</span>
+		<div role="group">
+			<span role="tab">Item 1</span>
+			<span role="tab">Item 2</span>
+		</div>
 	</div>
 </div>
 ```


### PR DESCRIPTION
I certainly didn't know you can nest `group` roles, but the definition of `group` says you can, so here are some examples to ensure our implementations do:

https://www.w3.org/TR/wai-aria-1.1/#group

Need for Call for Review: 1 week

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
