### PR TITLE
scrollable-element-keyboard: inapplicable example 5 started failing

### DIFF
--- a/_rules/scrollable-element-keyboard-accessible-0ssw9k.md
+++ b/_rules/scrollable-element-keyboard-accessible-0ssw9k.md
@@ -49,6 +49,8 @@ This rule assumes that all [scrollable elements][scrollable] with visible conten
 
 Some browsers will automatically make any [scrollable element][scrollable] focusable to ensure keyboard accessibility. However, the browser does not include these elements in [sequential focus navigation][] when it has a negative number as a tabindex [attribute value][].
 
+There are also differences between browsers in if they make right padding scrollable. While some browsers allow scrolling the full border-width of the content of a scrollable region, others constrain scrolling to the content box instead.
+
 ## Background
 
 To ensure there is some element from which arrow keys can be used to control the scroll position, focus must be on or in a scrollable region. If scripts are used to prevent the keyboard events from reaching the scrollable region, this could still cause a keyboard accessibility issue. This must be tested separately.
@@ -226,7 +228,7 @@ This [scrollable][] `section` element has no [visible][] content.
 This `section` element has a [horizontal scroll distance][scrollable] that is less than its horizontal [padding][], and [vertical scroll distance][scrollable] that is less than its vertical [padding][].
 
 ```html
-<section style="height: 210px; width: 500px; overflow: scroll; padding: 30px;">
+<section style="height: 210px; width: 530px; overflow: scroll; padding: 30px 0 30px 30px;">
 	<div role="heading" aria-level="1">WCAG 2.1 Abstract</div>
 	<div style="width: 520px">
 		Web Content Accessibility Guidelines (WCAG) 2.1 covers a wide range of recommendations for making Web content more

--- a/_rules/scrollable-element-keyboard-accessible-0ssw9k.md
+++ b/_rules/scrollable-element-keyboard-accessible-0ssw9k.md
@@ -43,7 +43,7 @@ Each test target is either included in [sequential focus navigation][] or has a 
 
 ## Assumptions
 
-This rule assumes that all [scrollable elements][scrollable] with visible content need to be keyboard accessible. [Scrollable elements][scrollable] that do not need to be keyboard accessible, perhaps because their content is [purely decorative][] or because scroll can be controlled in some other keyboard accessible way such as through a button or custom scrollbar, may fail this rule but still satisfy [success criterion 2.1.1 Keyboard][].
+This rule assumes that all [scrollable elements][scrollable] with visible content need to be keyboard accessible. [Scrollable elements][scrollable] that do not need to be keyboard accessible, perhaps because their content is [purely decorative][], the scroll area is whitespace, or because scroll can be controlled in some other keyboard accessible way such as through a button or custom scrollbar, may fail this rule but still satisfy [success criterion 2.1.1 Keyboard][].
 
 ## Accessibility Support
 

--- a/_rules/scrollable-element-keyboard-accessible-0ssw9k.md
+++ b/_rules/scrollable-element-keyboard-accessible-0ssw9k.md
@@ -49,7 +49,7 @@ This rule assumes that all [scrollable elements][scrollable] with visible conten
 
 Some browsers will automatically make any [scrollable element][scrollable] focusable to ensure keyboard accessibility. However, the browser does not include these elements in [sequential focus navigation][] when it has a negative number as a tabindex [attribute value][].
 
-There are also differences between browsers in if they make right padding scrollable. While some browsers allow scrolling the full border-width of the content of a scrollable region, others constrain scrolling to the content box instead.
+Some browsers restrict scrolling to the [content box](https://drafts.csswg.org/css-box-4/#content-box) of elements; while others allow to scroll the full [border box](https://drafts.csswg.org/css-box-4/#border-box), hence including the element's padding. This results in some elements being scrollable with a browser but not with another.
 
 ## Background
 


### PR DESCRIPTION
Chrome 96 changed how it padding-right interacts with scrollbar. In previous versions, and still in all other major browser it would pretend right padding does not exist for the purpose of scrolling. Effectively just making the box wider by the amount of padding-right that it has, and pretending that padding-right is 0. That's no longer the case, and so this inapplicable example was suddenly a failure.

I've updated this example so that it functions consistently again in all major browsers.

**Edge 95**

![Inapplicable example 5, text can not be scrolled off screen in Edge 95](https://user-images.githubusercontent.com/530687/142212566-b0eb4315-90d5-4a18-8711-b298b5c9ee14.png)

**Chrome 96**

![Inapplicable example 5, text scrolled off screen in Chrome 96](https://user-images.githubusercontent.com/530687/142212466-5cbca546-0ea2-426c-93e4-5dc3f4556166.png)

Here's a link to the example so you can see for yourself:
https://act-rules.github.io/testcases/0ssw9k/9646f97144271b3e95b6648f5814085ddaa8ee08.html

Need for Call for Review: 1 week, **but will be merged first due to the urgency of it**

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
