### PR TITLE
Remove 2 WCAG references:  1.3.1 and 4.1.2

### DIFF
--- a/_rules/aria-hidden-no-focusable-content-6cfa84.md
+++ b/_rules/aria-hidden-no-focusable-content-6cfa84.md
@@ -5,12 +5,7 @@ rule_type: atomic
 description: |
   This rule checks that elements with an `aria-hidden` attribute do not contain focusable elements.
 accessibility_requirements:
-  wcag20:1.3.1: # Info and Relationships (A)
-    forConformance: true
-    failed: not satisfied
-    passed: further testing needed
-    inapplicable: further testing needed
-  wcag20:4.1.2: # Name, Role, Value (A)
+  wcag20:2.4.3: # Focus Order (A)
     forConformance: true
     failed: not satisfied
     passed: further testing needed


### PR DESCRIPTION
Removed 1.3.1 and 4.1.2 as feel this applies to 2.4.3 more (a single checkpoint)

Asked to make sure there is only 1 SC dependency and this rule fits more to 2.4.3 than 1.3.1 and 4.1.2.

Closes issue(s):

N/A

Need for Call for Review:
This will require a 1 week Call for Review 