### PR TITLE
Remove 2nd WCAG reference: 1.4.9

### DIFF
--- a/_rules/image-no-text-0va7u6.md
+++ b/_rules/image-no-text-0va7u6.md
@@ -10,11 +10,6 @@ accessibility_requirements:
     failed: not satisfied
     passed: further testing needed
     inapplicable: further testing needed
-  wcag20:1.4.9: # Images of Text (No Exception) (AA)
-    forConformance: true
-    failed: not satisfied
-    passed: further testing needed
-    inapplicable: further testing needed
 input_aspects:
   - DOM Tree
   - CSS Styling


### PR DESCRIPTION
Removed the 2nd WCAG criteria that is AAA as the next level of compliance for this rule (no exceptions for the logo etc. This might be valid to stay in though.

Closes issue(s):

N/A

Need for Call for Review:
This will require a 1 week Call for Review 