### PR TITLE
Remove 2nd WCAG reference: 1.1.1

### DIFF
--- a/_rules/image-button-non-empty-accessible-name-59796f.md
+++ b/_rules/image-button-non-empty-accessible-name-59796f.md
@@ -5,11 +5,6 @@ rule_type: atomic
 description: |
   This rule checks that each image button element has a non-empty accessible name.
 accessibility_requirements:
-  wcag20:1.1.1: # Non-Text Content (A)
-    forConformance: true
-    failed: not satisfied
-    passed: further testing needed
-    inapplicable: further testing needed
   wcag20:4.1.2: # Name, Role, Value (A)
     forConformance: true
     failed: not satisfied


### PR DESCRIPTION
Removed 1.1.1 as for actionable form controls 4.1.2 is referred to as the checkpoint for controls and input: Controls, Input: If non-text content is a control or accepts user input, then it has a name that describes its purpose. (Refer to Success Criterion 4.1.2 for additional requirements for controls and content that accepts user input.)

Closes issue(s):

N/A

Need for Call for Review:
This will require a 1 week Call for Review 