### PR TITLE
Remove the 2nd WCAG reference: 2.4.9

### DIFF
--- a/_rules/link-in-context-descriptive-5effbb.md
+++ b/_rules/link-in-context-descriptive-5effbb.md
@@ -10,11 +10,6 @@ accessibility_requirements:
     failed: not satisfied
     passed: further testing needed
     inapplicable: further testing needed
-  wcag20:2.4.9: # Link Purpose (Link Only)
-    forConformance: true
-    failed: not satisfied
-    passed: further testing needed
-    inapplicable: further testing needed
 input_aspects:
   - Accessibility Tree
   - DOM Tree


### PR DESCRIPTION
Removed 2.4.9 as if 2.4.4 fails and this rule is including the context surrounding the link, then 2.4.9 fails.

Closes issue(s):

N/A

Need for Call for Review:
This will require a 1 week Call for Review 