### PR TITLE
Remove 2nd WCAG reference: 3.2.5

### DIFF
--- a/_rules/meta-refresh-no-delay-no-exception-bisz58.md
+++ b/_rules/meta-refresh-no-delay-no-exception-bisz58.md
@@ -10,11 +10,6 @@ accessibility_requirements:
     failed: not satisfied
     passed: further testing needed
     inapplicable: further testing needed
-  wcag20:3.2.5: # Change on Request (AAA)
-    forConformance: true
-    failed: not satisfied
-    passed: further testing needed
-    inapplicable: further testing needed
   wcag-technique:G110: # Using an instant client-side redirect
     forConformance: false
     failed: not satisfied


### PR DESCRIPTION
Removed 3.2.5 as the no exceptions part is more for the 2.2.4 but it is a grey area/hard to decide here.

Closes issue(s):

N/A

Need for Call for Review:
This will require a 1 week Call for Review 