### PR TITLE
Add note to button has accessible name rule to explain the exception #97a4e1

### DIFF
--- a/_rules/button-non-empty-accessible-name-97a4e1.md
+++ b/_rules/button-non-empty-accessible-name-97a4e1.md
@@ -42,6 +42,8 @@ Each target element has an [accessible name][] that is not empty (`""`).
 
 ## Background
 
+This rule considers an exception for "image buttons" (i.e., `input` elements with a `type` [attribute value] of `image`). Image buttons failing this rule would fail [Success Criterion 4.1.2](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value) and [Success Criterion 1.1.1](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content) which is not part of the accessibility requirements for this rule.
+
 ### Related rules
 
 - [Image button has non-empty accessible name](https://act-rules.github.io/rules/59796f)


### PR DESCRIPTION
The [CG decided](https://www.w3.org/2022/03/24-act-r-minutes.html#item04) to add a note explaining the reason for the image buttons exception in the [button has non-empty accessible name ](https://act-rules.github.io/rules/97a4e1)rule.

Need for Call for Review:
This will require a 1 week Call for Review

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
