### PR TITLE
form label descriptive: Tweak the examples

### DIFF
--- a/_rules/form-field-label-descriptive-cc0f0a.md
+++ b/_rules/form-field-label-descriptive-cc0f0a.md
@@ -140,11 +140,11 @@ The `label` elements are [programmatic labels][programmatic label] of their resp
 
 ```html
 <html lang="en">
-	<h2>Shipping address</h2>
+	<h2>Shipping</h2>
 	<label>Name<input id="shipping-name" type="text" name="name"/></label>
 	<label>Street<input id="shipping-street" type="text" name="street"/></label>
 
-	<h2>Billing address</h2>
+	<h2>Billing</h2>
 	<label>Name<input id="billing-name" type="text" name="name"/></label>
 	<label>Street<input id="billing-street" type="text" name="street"/></label>
 </html>
@@ -156,7 +156,7 @@ Both the `div` and the `span` elements are [programmatic labels][programmatic la
 
 ```html
 <html lang="en">
-	<div id="shipping">Shipping address</div>
+	<div id="shipping">Shipping</div>
 	<span id="name">Name</span>
 	<input id="shipping-name" type="text" name="name" aria-labelledby="shipping name" />
 </html>
@@ -202,11 +202,11 @@ The `label` elements are [programmatic labels][programmatic label] of their resp
 
 ```html
 <html lang="en">
-	<h2 style="position: absolute; top: -9999px; left: -9999px;">Shipping address</h2>
+	<h2 style="position: absolute; top: -9999px; left: -9999px;">Shipping</h2>
 	<input aria-label="Name" id="shipping-name" type="text" name="name" />
 	<input aria-label="Street" id="shipping-street" type="text" name="street" />
 
-	<h2 style="position: absolute; top: -9999px; left: -9999px;">Billing address</h2>
+	<h2 style="position: absolute; top: -9999px; left: -9999px;">Billing</h2>
 	<input aria-label="Name" id="billing-name" type="text" name="name" />
 	<input aria-label="Street" id="billing-street" type="text" name="street" />
 </html>
@@ -218,7 +218,7 @@ Both the `div` and the `span` elements are [programmatic labels][programmatic la
 
 ```html
 <html lang="en">
-	<div id="shipping">Shipping address</div>
+	<div id="shipping">Shipping</div>
 	<span id="name" style="display: none">Name</span>
 	<input id="shipping-name" type="text" name="name" aria-labelledby="shipping name" />
 </html>


### PR DESCRIPTION
Particularly failed example 5 I think is a little more difficult than it needs to be. If I encounter a form field that has a label above it saying "shipping address" I think the logical conclusion there is that it's an address field. That there's a hidden "name" field also makes this a little more confusing. By just using "shipping", it's clearer that information is missing.

Alternatively, or maybe additionally, we could add a second field with a hidden label to failed example 5?

Need for Call for Review: 1 week

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
