### PR TITLE
Update implementation info

### DIFF
--- a/__tests__/spelling-ignore.yml
+++ b/__tests__/spelling-ignore.yml
@@ -245,6 +245,8 @@
 - TestSubject
 - earl:cantTell
 - getComputedPriority
+- isPartOf
+- scId
 
 # sizes
 - 1em

--- a/pages/implementations/earl-reports.md
+++ b/pages/implementations/earl-reports.md
@@ -6,7 +6,7 @@ title: Reporting Format
 
 If you developed an accessibility tool or a testing methodology and would like to have your implementation included in the WAI website, there are two ways you can do so.
 
-1. If you have a tool that can return a data format, you will need to run your tests against the [ACT test cases](../testcases/) and [submit a report](../reporting/).
+1. If you have a tool that can return a data format, you will need to run your tests against the ACT [test cases](../testcases/) and [submit a report](../reporting/).
 2. If you have a manual test methodology where you fill results into some report template or semi-automated tool, you [can use the ACT Implementor tool](https://act-implementor.netlify.app/#/) instead to produce implementation reports.
 
 ## Understanding the Reporting format

--- a/pages/implementations/earl-reports.md
+++ b/pages/implementations/earl-reports.md
@@ -82,9 +82,9 @@ The following properties are required for each Assertion:
 
 ### Test Criterion
 
-For each result, we'll need to know which rule or procedure in the tool reported it, and which WCAG success criteria were failed. To do so, on the `test` property add an object. This must include:
+For each result, we'll need to know which rule or procedure in the tool reported it, and which WCAG success criteria were failed. To do so, on the `test` property, add an object. This must include:
 
-- `title`: A string, the uniquely identifies what rule or procedure in the tool found the result.
+- `title`: A string, that uniquely identifies which rule or procedure in the tool found the result.
 - `isPartOf`: An array of strings, listing the WCAG success criteria that fail when the rule or procedure fails. These must use the IDs of the WCAG success criteria, prefaced with `WCAG2:`. For example `WCAG2:name-role-value`.
 
 ```json
@@ -111,4 +111,4 @@ For each result, we'll need to know which rule or procedure in the tool reported
 
 **Note**: The IDs of WCAG success criteria can be found in [sc-urls.json](https://github.com/act-rules/act-tools/blob/main/src/data/sc-urls.json), on the `scId` property. These are the IDs introduced in WCAG 2.1, and continued in WCAG 2.2. Use these IDs, even when reporting for WCAG 2.0.
 
-**Advanced**: All required properties map to [EARL](http://www.w3.org/ns/earl#), except for `title` and `source` which are properties of [Dublin Core](http://purl.org/dc/terms/). Property names can be anything, as long as they can be expanded to the correct URL.
+**Advanced**: All required properties map to [EARL](http://www.w3.org/ns/earl#), except for `isPartOf`, `title`, and `source` which are properties of [Dublin Core](http://purl.org/dc/terms/). Property names can be anything, as long as they can be expanded to the correct URL.

--- a/pages/implementations/earl-reports.md
+++ b/pages/implementations/earl-reports.md
@@ -11,7 +11,7 @@ If you developed an accessibility tool or a testing methodology and would like t
 
 ## Understanding the Reporting format
 
-To display an accessibility test tool or methodology on the WAI website, use the [Evaluation And Reporting Language](https://www.w3.org/TR/EARL10-Schema/) expressed using [JSON-LD](https://json-ld.org). Tool developers that have an EARL reporter should be able to provide their existing reports. If you don't already have an EARL reporter, we provided a basic data structure that you can use.
+To display an accessibility test tool or methodology on the WAI website, use the [Evaluation And Reporting Language](https://www.w3.org/TR/EARL10-Schema/) expressed using [JSON-LD](https://www.w3.org/TR/json-ld/). Tool developers that have an EARL reporter should be able to provide their existing reports. If you don't already have an EARL reporter, we provided a basic data structure that you can use.
 
 ### Context And Graph
 

--- a/pages/implementations/earl-reports.md
+++ b/pages/implementations/earl-reports.md
@@ -11,7 +11,7 @@ If you developed an accessibility tool or a testing methodology and would like t
 
 ## Understanding the Reporting format
 
-To display a accessibility test tool or methodology on the WAI website, use the [Evaluation And Reporting Language](https://www.w3.org/TR/EARL10-Schema/) expressed using [JSON-LD](https://json-ld.org). Tool developers that have an EARL reporter should be able to provide their existing reports. If you don't already have an EARL reporter, we provided a basic data structure that you can use.
+To display an accessibility test tool or methodology on the WAI website, use the [Evaluation And Reporting Language](https://www.w3.org/TR/EARL10-Schema/) expressed using [JSON-LD](https://json-ld.org). Tool developers that have an EARL reporter should be able to provide their existing reports. If you don't already have an EARL reporter, we provided a basic data structure that you can use.
 
 ### Context And Graph
 

--- a/pages/implementations/earl-reports.md
+++ b/pages/implementations/earl-reports.md
@@ -4,14 +4,14 @@ title: Reporting Format
 
 ## Contribute An Implementation
 
-If you developed an accessibility tool or a testing methodology, and would like to have your implementation included in the ACT-R website, there are two ways you can do so.
+If you developed an accessibility tool or a testing methodology and would like to have your implementation included in the WAI website, there are two ways you can do so.
 
 1. If you have a tool that can return a data format, you will need to run your tests against the [ACT-R test cases](../testcases/) and [submit a report](../reporting/).
-2. If you use manual test methodology, where you fill results into some report template or tool, you can [Use the WCAG-EM Report Tool](../wcag-em-tool/) instead to produce implementation reports.
+2. If you have a manual test methodology where you fill results into some report template or semi-automated tool, you [can use the ACT Implementor tool](https://act-implementor.netlify.app/#/) instead to produce implementation reports.
 
 ## Understanding the Reporting format
 
-To display a accessibility test tool or methodology on the ACT-R Community website, ACT-R use the [Evaluation And Reporting Language](https://www.w3.org/TR/EARL10-Schema/) expressed using [JSON-LD](https://json-ld.org). Tool developers that have an EARL reporter should be able to provide their existing reports. If you don't already have an EARL reporter, we provided a basic data structure that you can use.
+To display a accessibility test tool or methodology on the WAI website, use the [Evaluation And Reporting Language](https://www.w3.org/TR/EARL10-Schema/) expressed using [JSON-LD](https://json-ld.org). Tool developers that have an EARL reporter should be able to provide their existing reports. If you don't already have an EARL reporter, we provided a basic data structure that you can use.
 
 ### Context And Graph
 
@@ -52,7 +52,7 @@ Add an `Assertion` object to the `assertions` array for each outcome provided by
 The following properties are required for each Assertion:
 
 - `@type`: This must be `Assertion`, to distinguish it from other data types that might exist in an EARL report.
-- `test.title`: A title for the rule / test procedure as it is known in the implementation
+- `test`: See [Test Criterion](#test-criterion).
 - `result.outcome`: One of the following values:
 
   - `earl:passed`: A node in the test case passed the rule
@@ -71,13 +71,44 @@ The following properties are required for each Assertion:
 			"assertions": [
 				{
 					"@type": "Assertion",
-					"test": { "title": "My Tool's rule title" },
-					"result": { "outcome": "earl:passed" }
+					"result": { "outcome": "earl:passed" },
+					"test": { ... },
 				}
 			]
 		}
 	]
 }
 ```
+
+### Test Criterion
+
+For each result, we'll need to know which rule or procedure in the tool reported it, and which WCAG success criteria were failed. To do so, on the `test` property add an object. This must include:
+
+- `title`: A string, the uniquely identifies what rule or procedure in the tool found the result.
+- `isPartOf`: An array of strings, listing the WCAG success criteria that fail when the rule or procedure fails. These must use the IDs of the WCAG success criteria, prefaced with `WCAG2:`. For example `WCAG2:name-role-value`.
+
+```json
+{
+	"@context": "https://act-rules.github.io/earl-context.json",
+	"@graph": [
+		{
+			"@type": "TestSubject",
+			"source": "https://act-rules.github.io/testcases/a1b64e/6c3ac31577c3cb2d968fc26c4075dd533b5513fc.html",
+			"assertions": [
+				{
+					"@type": "Assertion",
+					"result": { "outcome": "earl:passed" },
+					"test": {
+						"title": "image-button-has-name",
+						"isPartOf": ["WCAG2:non-text-content", "WCAG2:name-role-value"]
+					}
+				}
+			]
+		}
+	]
+}
+```
+
+**Note**: The IDs of WCAG success criteria can be found in [sc-urls.json](https://github.com/act-rules/act-tools/blob/main/src/data/sc-urls.json), on the `scId` property. These are the IDs introduced in WCAG 2.1, and continued in WCAG 2.2. Use these IDs, even when reporting for WCAG 2.0.
 
 **Advanced**: All required properties map to [EARL](http://www.w3.org/ns/earl#), except for `title` and `source` which are properties of [Dublin Core](http://purl.org/dc/terms/). Property names can be anything, as long as they can be expanded to the correct URL.

--- a/pages/implementations/earl-reports.md
+++ b/pages/implementations/earl-reports.md
@@ -6,7 +6,7 @@ title: Reporting Format
 
 If you developed an accessibility tool or a testing methodology and would like to have your implementation included in the WAI website, there are two ways you can do so.
 
-1. If you have a tool that can return a data format, you will need to run your tests against the ACT [test cases](../testcases/) and [submit a report](../reporting/).
+1. If you have a tool that can return a data format, you will need to run your tests against the [test cases](../testcases/) and [submit a report](../reporting/).
 2. If you have a manual test methodology where you fill results into some report template or semi-automated tool, you [can use the ACT Implementor tool](https://act-implementor.netlify.app/#/) instead to produce implementation reports.
 
 ## Understanding the Reporting format

--- a/pages/implementations/earl-reports.md
+++ b/pages/implementations/earl-reports.md
@@ -6,7 +6,7 @@ title: Reporting Format
 
 If you developed an accessibility tool or a testing methodology and would like to have your implementation included in the WAI website, there are two ways you can do so.
 
-1. If you have a tool that can return a data format, you will need to run your tests against the [ACT-R test cases](../testcases/) and [submit a report](../reporting/).
+1. If you have a tool that can return a data format, you will need to run your tests against the [ACT test cases](../testcases/) and [submit a report](../reporting/).
 2. If you have a manual test methodology where you fill results into some report template or semi-automated tool, you [can use the ACT Implementor tool](https://act-implementor.netlify.app/#/) instead to produce implementation reports.
 
 ## Understanding the Reporting format

--- a/pages/implementations/testcases.md
+++ b/pages/implementations/testcases.md
@@ -8,7 +8,7 @@ All ACT rules include a number of test cases, which are designed for easy consum
 	See the Test Cases JSON
  </a>
 
-**Note**: HTML test cases are embedded in a small template which adds a `!doctype`, HTML root node with lang attribute, and head with a title. These are omitted for test cases with an HTML element or a doctype.
+**Note**: HTML test cases are embedded in a small template which adds a `!DOCTYPE`, HTML root node with lang attribute, and head with a title. These are omitted for test cases with an HTML element or a `!DOCTYPE`.
 
 ## Test Case Format
 

--- a/pages/implementations/testcases.md
+++ b/pages/implementations/testcases.md
@@ -4,11 +4,11 @@ title: Test Cases
 
 All ACT rules include a number of test cases, which are designed for easy consumption by accessibility test tools and test methodologies. Test cases are updated regularly as part of rule writing. All test cases are described in a JSON file:
 
- <a class='btn' href='/testcases.json'>
-  See the Test Cases JSON
+ <a class='btn' href='https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases.json'>
+	See the Test Cases JSON
  </a>
 
-**Note**: Based on the file extension specified for a test case within the examples code snippet (e.g.: html, svg, xhtml), the corresponding `DOCTYPE`, if applicable, is dynamically added to the generated HTML test case file.
+**Note**: HTML test cases are embedded in a small template which adds a `!doctype`, HTML root node with lang attribute, and head with a title. These are omitted for test cases with an HTML element or a doctype.
 
 ## Test Case Format
 
@@ -24,19 +24,29 @@ In the `testcases.json` file, test cases are included on the `testcases` array, 
 
 ```json
 {
-  "name": "ACT-Rules Community test cases",
-  "license": "https://act-rules.github.io/pages/license/",
-  "count": 558,
-  "testcases": [
-    {
-      "testcaseId": "55f3ed0ec0f324514a0d223b737bc1e4c81593c7",
-      "url": "https://act-rules.github.io/testcases/5f99a7/55f3ed0ec0f324514a0d223b737bc1e4c81593c7.html",
-      "expected": "passed",
-      "ruleId": "5f99a7",
-      "ruleName": "ARIA attribute is valid",
-      "rulePage": "https://act-rules.github.io/rules/5f99a7",
-      "ruleAccessibilityRequirements": ["wcag20:4.1.2"]
-    }, ... ]
+	"name": "ACT Task Force test cases",
+	"website": "https://www.w3.org/WAI/standards-guidelines/act/rules/",
+	"license": "https://act-rules.github.io/pages/license/",
+	"count": 1132,
+	"testcases": [
+		{
+			"ruleId": "97a4e1",
+			"ruleName": "Button has non-empty accessible name",
+			"ruleAccessibilityRequirements": {
+				"wcag20:4.1.2": {
+					"forConformance": true,
+					"failed": "not satisfied",
+					"passed": "further testing needed",
+					"inapplicable": "further testing needed"
+				}
+			},
+			"expected": "passed",
+			"testcaseId": "a4cc71b0434f71f4ea0069c409f73e0207dfb403",
+			"testcaseTitle": "Passed Example 1",
+			"relativePath": "testcases/97a4e1/a4cc71b0434f71f4ea0069c409f73e0207dfb403.html",
+			"url": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/97a4e1/a4cc71b0434f71f4ea0069c409f73e0207dfb403.html",
+			"rulePage": "https://www.w3.org/WAI/standards-guidelines/act/rules/97a4e1/proposed/"
+		}, ... ]
 }
 ```
 
@@ -52,7 +62,7 @@ Correctness of an implementation is based on the results for test cases. See [im
 
 ## Contribute An Implementation
 
-If you developed an accessibility tool or a testing methodology, and would like to have your implementation included in the ACT-R website, there are two ways you can do so.
+If you developed an accessibility tool or a testing methodology, and would like to have your implementation included in the WAI website, there are two ways you can do so.
 
 1. If you have a tool that can return a data format, you will need to run your tests against the ACT rule's test cases and [submit a report](../reporting/).
 


### PR DESCRIPTION
This is the next step in migrating ACT implementation data over to the W3C website. The plan for it is as follows:

1. [x] Create new definitions for consistent and coverage
2. [x] Create tooling can report on the new consistency and coverage
3. [x] Document the updated requirements for EARL (This PR)
4. [x] Create and link to test cases of approved rules
5. [ ] Have implementors create new reports for WAI, keeping the existing reports as-is
6. [ ] Publish and announce the ACT implementation matrix
7. [ ] Start tracking proposed test cases for approved rules

Need for Call for Review: None, editorial

---


## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
