### PR TITLE
Update format for rule names

### DIFF
--- a/__tests__/spelling-ignore.yml
+++ b/__tests__/spelling-ignore.yml
@@ -16,6 +16,7 @@
 - xhtml
 - DOCTYPE
 - iFrame # used to demonstrate bad spelling
+- Iframe
 - feImage
 
 # Domain-specific words, Definitions & other allowed terms

--- a/_rules/aria-attr-defined-5f99a7.md
+++ b/_rules/aria-attr-defined-5f99a7.md
@@ -1,6 +1,6 @@
 ---
 id: 5f99a7
-name: '`aria-*` attribute is defined in WAI-ARIA'
+name: ARIA attribute is defined in WAI-ARIA
 rule_type: atomic
 description: |
   This rule checks that each `aria-` attribute specified is defined in ARIA 1.1.

--- a/_rules/aria-hidden-no-focusable-content-6cfa84.md
+++ b/_rules/aria-hidden-no-focusable-content-6cfa84.md
@@ -1,6 +1,6 @@
 ---
 id: 6cfa84
-name: Element with `aria-hidden` has no focusable content
+name: Element with aria-hidden has no focusable content
 rule_type: atomic
 description: |
   This rule checks that elements with an `aria-hidden` attribute do not contain focusable elements.

--- a/_rules/audio-as-media-alternative-afb423.md
+++ b/_rules/audio-as-media-alternative-afb423.md
@@ -1,6 +1,6 @@
 ---
 id: afb423
-name: '`audio` element content is media alternative for text'
+name: Audio element content is media alternative for text
 rule_type: atomic
 description: |
   This rule checks that the `audio` element is a media alternative for text on the page.

--- a/_rules/audio-or-video-avoids-automatically-playing-audio-80f0bf.md
+++ b/_rules/audio-or-video-avoids-automatically-playing-audio-80f0bf.md
@@ -1,6 +1,6 @@
 ---
 id: 80f0bf
-name: '`audio` or `video` avoids automatically playing audio'
+name: Audio or video avoids automatically playing audio
 rule_type: composite
 description: |
   This rule checks that audio or video that plays automatically does not have audio that lasts for more than 3 seconds or has an audio control mechanism to stop or mute it.

--- a/_rules/audio-or-video-avoids-automatically-playing-audio-80f0bf.md
+++ b/_rules/audio-or-video-avoids-automatically-playing-audio-80f0bf.md
@@ -1,6 +1,6 @@
 ---
 id: 80f0bf
-name: Audio or video avoids automatically playing audio
+name: Audio or video element avoids automatically playing audio
 rule_type: composite
 description: |
   This rule checks that audio or video that plays automatically does not have audio that lasts for more than 3 seconds or has an audio control mechanism to stop or mute it.

--- a/_rules/audio-text-alternative-e7aa44.md
+++ b/_rules/audio-text-alternative-e7aa44.md
@@ -1,6 +1,6 @@
 ---
 id: e7aa44
-name: '`audio` element content has text alternative'
+name: Audio element content has text alternative
 rule_type: composite
 description: |
   This rule checks that `audio` elements have a text alternative available.

--- a/_rules/audio-transcript-2eb176.md
+++ b/_rules/audio-transcript-2eb176.md
@@ -1,6 +1,6 @@
 ---
 id: 2eb176
-name: '`audio` element content has transcript'
+name: Audio element content has transcript
 rule_type: atomic
 description: |
   This rule checks that `audio` elements have a transcript that includes all auditory information.

--- a/_rules/auto-play-audio-does-not-exceed-3-seconds-aaa1bf.md
+++ b/_rules/auto-play-audio-does-not-exceed-3-seconds-aaa1bf.md
@@ -1,6 +1,6 @@
 ---
 id: aaa1bf
-name: '`Audio` or `video` that plays automatically has no audio that lasts more than 3 seconds'
+name: Audio or video that plays automatically has no audio that lasts more than 3 seconds
 rule_type: atomic
 description: |
   `audio` or `video` that plays automatically does not output audio for more than 3 seconds.

--- a/_rules/auto-play-audio-does-not-exceed-3-seconds-aaa1bf.md
+++ b/_rules/auto-play-audio-does-not-exceed-3-seconds-aaa1bf.md
@@ -1,6 +1,6 @@
 ---
 id: aaa1bf
-name: Audio or video that plays automatically has no audio that lasts more than 3 seconds
+name: Audio or video element that plays automatically has no audio that lasts more than 3 seconds
 rule_type: atomic
 description: |
   `audio` or `video` that plays automatically does not output audio for more than 3 seconds.

--- a/_rules/auto-play-audio-has-control-mechanism-4c31df.md
+++ b/_rules/auto-play-audio-has-control-mechanism-4c31df.md
@@ -1,6 +1,6 @@
 ---
 id: 4c31df
-name: Audio or video that plays automatically has a control mechanism
+name: Audio or video element that plays automatically has a control mechanism
 rule_type: atomic
 description: |
   audio or video that plays automatically must have a control mechanism.

--- a/_rules/auto-play-audio-has-control-mechanism-4c31df.md
+++ b/_rules/auto-play-audio-has-control-mechanism-4c31df.md
@@ -1,6 +1,6 @@
 ---
 id: 4c31df
-name: '`audio` or `video` that plays automatically has a control mechanism'
+name: Audio or video that plays automatically has a control mechanism
 rule_type: atomic
 description: |
   audio or video that plays automatically must have a control mechanism.

--- a/_rules/autocomplete-valid-value-73f2c2.md
+++ b/_rules/autocomplete-valid-value-73f2c2.md
@@ -1,6 +1,6 @@
 ---
 id: 73f2c2
-name: '`autocomplete` attribute has valid value'
+name: Autocomplete attribute has valid value
 rule_type: atomic
 description: |
   This rule checks that the HTML `autocomplete` attribute has a correct value.

--- a/_rules/element-lang-valid-de46e4.md
+++ b/_rules/element-lang-valid-de46e4.md
@@ -1,6 +1,6 @@
 ---
 id: de46e4
-name: Element with `lang` attribute has valid language tag
+name: Element with lang attribute has valid language tag
 rule_type: atomic
 description: |
   This rule checks that a non-empty `lang` attribute of an element in the page has a language tag with a known primary language subtag.

--- a/_rules/explicit-SVG-image-non-empty-accessible-name-7d6734.md
+++ b/_rules/explicit-SVG-image-non-empty-accessible-name-7d6734.md
@@ -1,6 +1,6 @@
 ---
 id: 7d6734
-name: '`svg` element with explicit role has non-empty accessible name'
+name: SVG element with explicit role has non-empty accessible name
 rule_type: atomic
 description: |
   This rule checks that each SVG image element that is explicitly included in the accessibility tree has a non-empty accessible name.

--- a/_rules/html-page-lang-b5c3f8.md
+++ b/_rules/html-page-lang-b5c3f8.md
@@ -1,6 +1,6 @@
 ---
 id: b5c3f8
-name: HTML page has `lang` attribute
+name: HTML page has lang attribute
 rule_type: atomic
 description: |
   This rule checks that an HTML page has a non-empty `lang` attribute.

--- a/_rules/html-page-lang-valid-bf051a.md
+++ b/_rules/html-page-lang-valid-bf051a.md
@@ -1,6 +1,6 @@
 ---
 id: bf051a
-name: HTML page `lang` attribute has valid language tag
+name: HTML page lang attribute has valid language tag
 rule_type: atomic
 description: |
   This rule checks that the `lang` attribute of the root element of a non-embedded HTML page has a language tag with a known primary language subtag.

--- a/_rules/html-page-lang-xml-lang-match-5b7ae0.md
+++ b/_rules/html-page-lang-xml-lang-match-5b7ae0.md
@@ -1,6 +1,6 @@
 ---
 id: 5b7ae0
-name: HTML page `lang` and `xml:lang` attributes have matching values
+name: HTML page lang and xml:lang attributes have matching values
 rule_type: atomic
 description: |
   This rule checks that both `lang` and `xml:lang` attributes on the root element of a non-embedded HTML page, have the same primary language subtag.

--- a/_rules/id-value-unique-3ea0c8.md
+++ b/_rules/id-value-unique-3ea0c8.md
@@ -1,6 +1,6 @@
 ---
 id: 3ea0c8
-name: '`id` attribute value is unique'
+name: Id attribute value is unique
 rule_type: atomic
 description: |
   This rule checks that all `id` attribute values on a single page are unique.

--- a/_rules/iframe-identical-name-equivalent-purpose-4b1c6c.md
+++ b/_rules/iframe-identical-name-equivalent-purpose-4b1c6c.md
@@ -1,6 +1,6 @@
 ---
 id: 4b1c6c
-name: '`iframe` elements with identical accessible names have equivalent purpose'
+name: Iframe elements with identical accessible names have equivalent purpose
 rule_type: atomic
 description: |
   This rule checks that `iframe` elements with identical accessible names embed the same resource or equivalent resources.

--- a/_rules/iframe-non-empty-accessible-name-cae760.md
+++ b/_rules/iframe-non-empty-accessible-name-cae760.md
@@ -1,6 +1,6 @@
 ---
 id: cae760
-name: '`iframe` element has non-empty accessible name'
+name: Iframe element has non-empty accessible name
 rule_type: atomic
 description: |
   This rule checks that each `iframe` element has a non-empty accessible name.

--- a/_rules/iframe-not-focusable-has-no-interactive-content-akn7bn.md
+++ b/_rules/iframe-not-focusable-has-no-interactive-content-akn7bn.md
@@ -1,6 +1,6 @@
 ---
 id: akn7bn
-name: iframe with negative tabindex has no interactive elements
+name: Iframe with negative tabindex has no interactive elements
 rule_type: atomic
 description: |
   This rule checks that `iframe` elements with a negative `tabindex` attribute value contain no interactive elements.

--- a/_rules/letter-spacing-not-important-24afc2.md
+++ b/_rules/letter-spacing-not-important-24afc2.md
@@ -1,6 +1,6 @@
 ---
 id: 24afc2
-name: Letter spacing in `style` attributes is not `!important`
+name: Letter spacing in style attributes is not !important
 rule_type: atomic
 description: |
   This rule checks that the `style` attribute is not used to prevent adjusting `letter-spacing` by using `!important`, except if it's at least 0.12 times the font size.

--- a/_rules/line-height-not-important-78fd32.md
+++ b/_rules/line-height-not-important-78fd32.md
@@ -1,6 +1,6 @@
 ---
 id: 78fd32
-name: Line height in `style` attributes is not `!important`
+name: Line height in style attributes is not !important
 rule_type: atomic
 description: |
   This rule checks that the `style` attribute is not used to prevent adjusting `line-height` by using `!important`, except if it's at least 1.5 times the font size.
@@ -37,13 +37,13 @@ For each test target, at least one of the following is true:
 
 - There is no mechanism available on the page to adjust [line-height][]. If there is such a mechanism, it is possible to fail this rule while [Success Criterion 1.4.12 Text Spacing][sc1412] is still satisfied.
 
-- The font size is constant for all text in the element. If font-size changes (e.g., through use of the `::first-line` pseudo-element) then the required line height would also change throughout the element. This is untested by the current rule. 
+- The font size is constant for all text in the element. If font-size changes (e.g., through use of the `::first-line` pseudo-element) then the required line height would also change throughout the element. This is untested by the current rule.
 
 - No other style attributes are used to increase or decrease the distance between lines of text. For example, style attributes such as `position`, `padding`, and `margin` could be used to increase the distance between lines of text to meet [Success Criterion 1.4.12 Text Spacing][sc1412]. Oppositely, those style attributes could also be used to reduce the distance between lines of text. Thus, it is possible to pass this rule, but still fail [Success Criterion 1.4.12 Text Spacing][sc1412] due to other styling choices.
 
 ## Accessibility Support
 
-While some assistive technologies are able to set [user origin][] or [user agent origin][] styles, others, such as browser extensions, are only able to set styles with the [author origin][]. Such assistive technologies cannot create styles "winning" the [cascade sort][] over a `style` attribute with an [important][] declaration. 
+While some assistive technologies are able to set [user origin][] or [user agent origin][] styles, others, such as browser extensions, are only able to set styles with the [author origin][]. Such assistive technologies cannot create styles "winning" the [cascade sort][] over a `style` attribute with an [important][] declaration.
 
 ## Background
 
@@ -54,7 +54,6 @@ CSS specifications define each declaration as being either [important][] (if is 
 This rule evaluates the [used][] value of the [line-height][] property instead of its [computed][] value because the [used][] value is guaranteed to use absolute units (i.e., pixels). This streamlines comparison with the [computed][] [font-size][] which is also absolute. The [computed][] [line-height][] may be a unitless number that is harder to compare.
 
 ### Bibliography
-
 
 - [Understanding Success Criterion 1.4.12: Text Spacing](https://www.w3.org/WAI/WCAG21/Understanding/text-spacing.html)
 - [CSS Text Module Level 3 - Spacing](https://www.w3.org/TR/css-text-3/#spacing)

--- a/_rules/meta-refresh-no-delay-bc659a.md
+++ b/_rules/meta-refresh-no-delay-bc659a.md
@@ -1,6 +1,6 @@
 ---
 id: bc659a
-name: Meta element has no refresh delay'
+name: Meta element has no refresh delay
 rule_type: atomic
 description: |
   This rule checks that the `meta` element is not used for delayed redirecting or refreshing.

--- a/_rules/meta-refresh-no-delay-bc659a.md
+++ b/_rules/meta-refresh-no-delay-bc659a.md
@@ -1,6 +1,6 @@
 ---
 id: bc659a
-name: '`meta` element has no refresh delay'
+name: Meta element has no refresh delay'
 rule_type: atomic
 description: |
   This rule checks that the `meta` element is not used for delayed redirecting or refreshing.

--- a/_rules/meta-refresh-no-delay-no-exception-bisz58.md
+++ b/_rules/meta-refresh-no-delay-no-exception-bisz58.md
@@ -1,6 +1,6 @@
 ---
 id: bisz58
-name: '`meta` element has no refresh delay (no exception)'
+name: Meta element has no refresh delay (no exception)
 rule_type: atomic
 description: |
   This rule checks that the `meta` element is not used for delayed redirecting or refreshing.

--- a/_rules/meta-viewport-b4f0c3.md
+++ b/_rules/meta-viewport-b4f0c3.md
@@ -1,6 +1,6 @@
 ---
 id: b4f0c3
-name: '`meta` `viewport` allows for zoom'
+name: Meta viewport allows for zoom
 rule_type: atomic
 description: |
   This rule checks that the `meta` element retains the user agent ability to zoom.

--- a/_rules/role-attribute-valid-value-674b10.md
+++ b/_rules/role-attribute-valid-value-674b10.md
@@ -1,6 +1,6 @@
 ---
 id: 674b10
-name: '`role` attribute has valid value'
+name: Role attribute has valid value
 rule_type: atomic
 description: |
   This rule checks that each `role` attribute has a valid value.

--- a/_rules/role-required-states-and-properties-4e8ab6.md
+++ b/_rules/role-required-states-and-properties-4e8ab6.md
@@ -1,6 +1,6 @@
 ---
 id: 4e8ab6
-name: Element with `role` attribute has required states and properties
+name: Element with role attribute has required states and properties
 rule_type: atomic
 description: |
   This rule checks that elements that have an explicit role also specify all required states and properties.

--- a/_rules/table-headers-attribute-refer-to-data-cells-a25f45.md
+++ b/_rules/table-headers-attribute-refer-to-data-cells-a25f45.md
@@ -1,6 +1,6 @@
 ---
 id: a25f45
-name: Headers attribute specified on a cell refers to cells in the same table element'
+name: Headers attribute specified on a cell refers to cells in the same table element
 rule_type: atomic
 description: |
   This rule checks that the `headers` attribute on a cell refer to other cells in the same `table` element.

--- a/_rules/table-headers-attribute-refer-to-data-cells-a25f45.md
+++ b/_rules/table-headers-attribute-refer-to-data-cells-a25f45.md
@@ -1,6 +1,6 @@
 ---
 id: a25f45
-name: '`headers` attribute specified on a cell refers to cells in the same `table` element'
+name: Headers attribute specified on a cell refers to cells in the same table element'
 rule_type: atomic
 description: |
   This rule checks that the `headers` attribute on a cell refer to other cells in the same `table` element.

--- a/_rules/video-alternative-for-auditory-eac66b.md
+++ b/_rules/video-alternative-for-auditory-eac66b.md
@@ -1,6 +1,6 @@
 ---
 id: eac66b
-name: '`video` element auditory content has accessible alternative'
+name: Video element auditory content has accessible alternative
 rule_type: composite
 description: |
   This rule checks that `video` elements have an alternative for information conveyed through audio.

--- a/_rules/video-alternative-for-visual-c5a4ea.md
+++ b/_rules/video-alternative-for-visual-c5a4ea.md
@@ -1,6 +1,6 @@
 ---
 id: c5a4ea
-name: '`video` element visual content has accessible alternative'
+name: Video element visual content has accessible alternative
 rule_type: composite
 description: |
   This rule checks that `video` elements with audio have an alternative for the video content as audio or as text.

--- a/_rules/video-as-media-alternative-ab4d13.md
+++ b/_rules/video-as-media-alternative-ab4d13.md
@@ -1,6 +1,6 @@
 ---
 id: ab4d13
-name: '`video` element content is media alternative for text'
+name: Video element content is media alternative for text
 rule_type: atomic
 description: |
   This rule checks non-streaming `video` is a media alternative for text on the page.

--- a/_rules/video-audio-description-1ea59c.md
+++ b/_rules/video-audio-description-1ea59c.md
@@ -1,6 +1,6 @@
 ---
 id: 1ea59c
-name: '`video` element visual content has audio description'
+name: Video element visual content has audio description
 rule_type: atomic
 description: |
   This rule checks that non-streaming `video` elements have all visual information also contained in the audio.

--- a/_rules/video-captions-f51b46.md
+++ b/_rules/video-captions-f51b46.md
@@ -1,6 +1,6 @@
 ---
 id: f51b46
-name: '`video` element auditory content has captions'
+name: Video element auditory content has captions
 rule_type: atomic
 description: |
   This rule checks that captions are available for audio information in non-streaming `video` elements.

--- a/_rules/video-description-track-f196ce.md
+++ b/_rules/video-description-track-f196ce.md
@@ -1,6 +1,6 @@
 ---
 id: f196ce
-name: 'DEPRECATED — `video` element visual content has description track'
+name: DEPRECATED — Video element visual content has description track
 rule_type: atomic
 description: |
   This rule checks that description tracks that come with non-streaming `video` elements are descriptive.

--- a/_rules/video-only-alternative-for-visual-c3232f.md
+++ b/_rules/video-only-alternative-for-visual-c3232f.md
@@ -1,6 +1,6 @@
 ---
 id: c3232f
-name: '`video` element visual-only content has accessible alternative'
+name: Video element visual-only content has accessible alternative
 rule_type: composite
 description: |
   This rule checks that `video` elements without audio have an alternative available.

--- a/_rules/video-only-as-media-alternative-fd26cf.md
+++ b/_rules/video-only-as-media-alternative-fd26cf.md
@@ -1,6 +1,6 @@
 ---
 id: fd26cf
-name: '`video` element visual-only content is media alternative for text'
+name: Video element visual-only content is media alternative for text
 rule_type: atomic
 description: |
   This rule checks non-streaming silent `video` is a media alternative for text on the page.

--- a/_rules/video-only-audio-track-d7ba54.md
+++ b/_rules/video-only-audio-track-d7ba54.md
@@ -1,6 +1,6 @@
 ---
 id: d7ba54
-name: '`video` element visual-only content has audio track alternative'
+name: Video element visual-only content has audio track alternative
 rule_type: atomic
 description: |
   Non-streaming `video` elements without audio must have an audio alternative.

--- a/_rules/video-only-description-track-ac7dc6.md
+++ b/_rules/video-only-description-track-ac7dc6.md
@@ -1,6 +1,6 @@
 ---
 id: ac7dc6
-name: 'DEPRECATED — `video` element visual-only content has description track'
+name: DEPRECATED — Video element visual-only content has description track
 rule_type: atomic
 description: |
   This rule checks that description tracks that come with non-streaming `video` elements, without audio, are descriptive.

--- a/_rules/video-only-transcript-ee13b5.md
+++ b/_rules/video-only-transcript-ee13b5.md
@@ -1,6 +1,6 @@
 ---
 id: ee13b5
-name: '`video` element visual-only content has transcript'
+name: Video element visual-only content has transcript
 rule_type: atomic
 description: |
   Non-streaming `video` elements without audio must have all visual information available in a transcript.

--- a/_rules/video-strict-alternative-for-visual-1ec09b.md
+++ b/_rules/video-strict-alternative-for-visual-1ec09b.md
@@ -1,6 +1,6 @@
 ---
 id: 1ec09b
-name: '`video` element visual content has strict accessible alternative'
+name: Video element visual content has strict accessible alternative
 rule_type: composite
 description: |
   This rule checks that `video` elements with audio have audio description.

--- a/_rules/video-transcript-1a02b0.md
+++ b/_rules/video-transcript-1a02b0.md
@@ -1,6 +1,6 @@
 ---
 id: 1a02b0
-name: 'Audio and visuals of `video` element have transcript'
+name: Audio and visuals of video element have transcript
 rule_type: atomic
 description: |
   This rule checks that non-streaming `video` elements have all audio and visual information available in a transcript.

--- a/_rules/word-spacing-not-important-9e45ec.md
+++ b/_rules/word-spacing-not-important-9e45ec.md
@@ -1,6 +1,6 @@
 ---
 id: 9e45ec
-name: Word spacing in `style` attributes is not `!important`
+name: Word spacing in style attributes is not !important
 rule_type: atomic
 description: |
   This rule checks that the `style` attribute is not used to prevent adjusting `word-spacing` by using `!important`, except if it's at least `0.16` times the font size.

--- a/pages/design/rule-design.md
+++ b/pages/design/rule-design.md
@@ -36,15 +36,14 @@ The rule name is its descriptive title. The agreed conventions for naming of rul
 
 - Be succinct, direct and declarative, and avoid unnecessary words, _e.g. an, the_.
 - Use declarative verbs, _e.g. has, have, is_.
-- Use back ticks to indicate words from code, _e.g. `label` v. Label_.
-- Identify code as an element or attribute as appropriate, _e.g. `title` element, `title` attribute_.
-- Use sentence case, _e.g. "Heading is descriptive"_, unless using code, _e.g. "`id` attribute value is unique"_, or initials, _e.g. "HTML page has title"_. Note: names starting with a backtick also need to be wrapped with quotes for the parser.
-- Use singular tense so that necessary plurals stand out, _e.g. "`video` element has captions"_.
+- Identify code as an element or attribute as appropriate, _e.g. title element, title attribute_.
+- Use sentence case, _e.g. "Heading is descriptive"_, including for code, _e.g. "Id attribute value is unique"_, or initials, _e.g. "HTML page has title"_.
+- Use singular tense so that necessary plurals stand out, _e.g. "Video element has captions"_.
 - Front load the applicable thing, _e.g. "Button has accessible name"_.
 - Refer to each applicable thing in a consistent way across rules, especially when related or checking the same applicable thing.
-- Describe the passing condition, _e.g. "`id` attribute value is unique", rather than "page has no duplicate `id`s"_.
-- Do not use hyphens or dashes unless correct for code, _e.g. `aria-*`_.
-- Do not use camelCase unless correct for code, _e.g. `iframe` not iFrame, `feImage` in SVG_.
+- Describe the passing condition, _e.g. "Id attribute value is unique", rather than "page has no duplicate id attributes"_.
+- Do not use hyphens or dashes unless correct for code, _e.g. aria-\*_.
+- Do not use camelCase unless correct for code, _e.g. iframe not iFrame, feImage in SVG_.
 - If unsure, refer to WCAG language used.
 - Aim to be unique, which should happen if title includes the applicable thing and passing condition.
 


### PR DESCRIPTION
- Remove backticks
- Remove single quotes
- Always capitalize

We have a number of places where rendering back ticks in rule names has proven difficult. We've previously stripped out the back ticks, but this ends up looking kinda strange, with some rule names capitalised and others not for no obvious reason. 

Need for Call for Review: 1 week

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
