### PR TITLE
ARIA required owned elm; fix parser issue in pass 3

### DIFF
--- a/_rules/aria-required-owned-element-bc4a75.md
+++ b/_rules/aria-required-owned-element-bc4a75.md
@@ -92,12 +92,14 @@ This element with the `tablist` role only owns elements with the `tab` role. The
 
 #### Passed Example 3
 
-This element with the `grid` role only owns elements with the `row` role, and the element with the `row` role only owns elements with the `cell` role. The `row` role is one of the [required owned elements][] for `grid`, and `cell` is one of the [required owned elements][] for `row`.
+This element with the `grid` role only owns elements with the `row` role, and the element with the `row` role only owns elements with the `cell` role. The `row` role is one of the [required owned elements][] for `grid`, and `cell` is one of the [required owned elements][] for `row`. The `td` element is ignored because it has an [explicit semantic role][] of `none`.
 
 ```html
 <table role="grid">
 	<tr role="row">
-		<span role="cell">Item 1</span>
+		<td role="none">
+			<span role="cell">Item 1</span>
+		</td>
 	</tr>
 </table>
 ```

--- a/_rules/aria-required-owned-element-bc4a75.md
+++ b/_rules/aria-required-owned-element-bc4a75.md
@@ -81,30 +81,16 @@ This element with the `list` role only owns elements with the `listitem` role. T
 
 #### Passed Example 2
 
-This element with the `tablist` role only owns elements with the `tab` role. The `tab` role is one of the [required owned elements][] for `tablist`.
-
-```html
-<ul role="tablist">
-	<li role="tab">Tab 1</li>
-	<li role="tab">Tab 2</li>
-</ul>
-```
-
-#### Passed Example 3
-
-This element with the `grid` role only owns elements with the `row` role, and the element with the `row` role only owns elements with the `cell` role. The `row` role is one of the [required owned elements][] for `grid`, and `cell` is one of the [required owned elements][] for `row`. The `td` element is ignored because it has an [explicit semantic role][] of `none`.
-
+This element with the `grid` role only owns elements with the `row` role, and the element with the `row` role only owns elements with the `cell` role. The `row` role is one of the [required owned elements][] for `grid`, and `cell` is one of the [required owned elements][] for `row`.
 ```html
 <table role="grid">
 	<tr role="row">
-		<td role="none">
-			<span role="cell">Item 1</span>
-		</td>
+		<td role="cell">Item 1</td>
 	</tr>
 </table>
 ```
 
-#### Passed Example 4
+#### Passed Example 3
 
 This element with the `menu` role only owns elements with the `menuitem`, `menuitemradio` and `menuitemcheckbox` role. These roles are all [required owned elements][] for `menu`. The element with the `none` role is not [owned by][] the `menu` because it is not [included in the accessibility tree][].
 
@@ -115,6 +101,18 @@ This element with the `menu` role only owns elements with the `menuitem`, `menui
 	<div role="menuitemradio" aria-checked="false">Item 2</div>
 	<div role="menuitemcheckbox" aria-checked="false">Item 3</div>
 </div>
+```
+
+#### Passed Example 4
+
+This element with the `tablist` role only owns elements with the `tab` role. The `tab` role is one of the [required owned elements][] for `tablist`. The `li` element is ignored because it has an [explicit semantic role][] of `none`.
+
+```html
+<ul role="tablist">
+	<li role="none">
+		<span role="tab">Tab 1</span>
+	</li>
+</ul>
 ```
 
 #### Passed Example 5


### PR DESCRIPTION
Browsers only allow `th` and `td` elements as children of `tr`. The `span` we used in passed example 3 gets booted out by the browser, and is instead rendered above the table inside the DOM tree. If you inspect the DOM of this code example, it'll look like this:

- `<body>`
    - `<span role="cell">`
    - `<table role="grid">`
        - `<tbody>`
            - `<tr role="row">`

Wrapping the span in a td with role=none should fix the issue, and I think, preserve the intent of the example.

Need for Call for Review: 1 week

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
