### PR TITLE
"Element with presentational children has no focusable content" [307n5z]: improve Accessibility Support note

### DIFF
--- a/_rules/presentational-children-no-focusable-content-307n5z.md
+++ b/_rules/presentational-children-no-focusable-content-307n5z.md
@@ -34,7 +34,7 @@ This rule assumes that elements that are part of [sequential focus navigation][]
 
 ## Accessibility Support
 
-Several major browsers ignore the WAI-ARIA requirements on [presentational children][] for most or sometimes all roles. Because some browsers do, and others do not implement presentational children, there can be significant differences between browsers.
+Several major browsers ignore the WAI-ARIA requirements on [presentational children][] for most or sometimes all roles; or in presence of focusable content. Because some browsers do, and others do not implement presentational children, there can be significant differences between browsers; and pages failing this rule may only be problematic with some browsers.
 
 ## Background
 


### PR DESCRIPTION
The Accessibility Support note mentioned discrepancies in handling presentational children in case around the `role` attribute. This explicits that browsers also act differently in case of focusable elements.

Closes issue(s): 

- closes #1851

Need for Call for Review:
This will not require a Call for Review (precision in Accessibility Support).

---

## Pull Request Etiquette

### **When creating PR:**

- [X] Make sure you're requesting to **pull a branch** (right side) to the `develop` branch (left side).
- [X] Make sure you do not remove the "How to Review and Approve" section in your pull request description

### **After creating PR:**

- [X] Add yourself (and co-authors) as "Assignees" for PR.
- [X] Add label to indicate if it's a `Rule`, `Definition` or `Chore`.
- [X] [Link the PR to any issue it solves](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue). This will be done automatically by [referencing the issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) at the top of this comment in the indicated place.
- [X] Optionally request feedback from anyone in particular by assigning them as "Reviewers".

### **When merging a PR:**

- [ ] Close any issue that the PR resolves. This will happen automatically upon merging if the PR was correctly linked to the issue, e.g. by referencing the issue at the top of this comment.

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
