### PR TITLE
Moved Failed Example 4 into Passed Example 9 in HTML images contain no text [0va7u6]

### DIFF
--- a/_rules/image-no-text-0va7u6.md
+++ b/_rules/image-no-text-0va7u6.md
@@ -42,11 +42,14 @@ Each test target has no [visible][] [text][human language], except if at least o
 
 - <dfn id="0va7u6:decorative">decorative</dfn>: The image with text is [purely decorative][]; or
 - <dfn id="0va7u6:incidental">incidental</dfn>: The text is not a [significant][insignificant] part of the image; or
-- <dfn id="0va7u6:essential">essential</dfn>: The presentation of the text is [essential][].
+- <dfn id="0va7u6:essential">essential</dfn>: The presentation of the text is [essential][]; or
+- <dfn id="0va7u6:redundant">redundant</dfn>: The same information conveyed by the image of text is also available as real text.
 
 ## Background
 
 This rule is designed specifically for [SC 1.4.5 Images of Text][sc1.4.5]. There are however only minimal differences between this criterion and [SC 1.4.9 Images of Text (No Exception)][sc1.4.9]. The two differences are that customizable images of text are allowed, and that images of text are allowed when the presentation cannot otherwise be achieved. These scenarios are so rare the rule ignores them as part of the assumptions, and so the [accessibility requirements mapping](#accessibility-requirements-mapping) of these two criteria is the same.
+
+[SC 1.4.5 Images of Text][sc1.4.5] explicitly clarifies in its note that the success criterion is meant to address cases where images of text are used instead of actual text. If images of text are used in addition to real text to convey the same information, then the success criterion is satisfied.
 
 ### Assumptions
 
@@ -166,6 +169,15 @@ These image resources referenced by the `input` elements are images of text (the
 />
 ```
 
+#### Passed Example 9
+
+This image resource referenced by the `img` element contains text that provides [redundant](#0va7u6:redundant) information. In fact, the same information conveyed by the image of text is also available as real text.
+
+```html
+<img src="/test-assets/0va7u6/welcome.png" alt="" />
+<p>Welcome to our website</p>
+```
+
 ### Failed
 
 #### Failed Example 1
@@ -193,15 +205,6 @@ This image resource referenced by the `background-image` property of the `div` e
 
 ```html
 <div style="background-image: url(/test-assets/0va7u6/textimage.jpg); width: 500px; height: 200px;" />
-```
-
-#### Failed Example 4
-
-This image resource referenced by the `img` element contains text that provides redundant information, but it still is information, therefore it is not [decorative](#0va7u6:decorative).
-
-```html
-<img src="/test-assets/0va7u6/welcome.png" alt="" />
-<p>Welcome to our website</p>
 ```
 
 #### Failed Example 5

--- a/_rules/image-no-text-0va7u6.md
+++ b/_rules/image-no-text-0va7u6.md
@@ -12,10 +12,7 @@ accessibility_requirements:
     passed: further testing needed
     inapplicable: further testing needed
   wcag20:1.4.9: # Images of Text (No Exception) (AAA)
-    forConformance: true
-    failed: not satisfied
-    passed: further testing needed
-    inapplicable: further testing needed
+    secondary: This success criterion is **more strict** than this rule. This is because the rule considers redundancy when information presented as an image of text is also conveyed in text. Some of the passed examples do not satisfy this success criterion.
 input_aspects:
   - DOM Tree
   - CSS Styling
@@ -49,7 +46,7 @@ Each test target has no [visible][] [text][human language], except if at least o
 
 This rule is designed specifically for [SC 1.4.5 Images of Text][sc1.4.5]. There are however only minimal differences between this criterion and [SC 1.4.9 Images of Text (No Exception)][sc1.4.9]. The two differences are that customizable images of text are allowed, and that images of text are allowed when the presentation cannot otherwise be achieved. These scenarios are so rare the rule ignores them as part of the assumptions, and so the [accessibility requirements mapping](#accessibility-requirements-mapping) of these two criteria is the same.
 
-[SC 1.4.5 Images of Text][sc1.4.5] explicitly clarifies in its note that the success criterion is meant to address cases where images of text are used instead of actual text. If images of text are used in addition to real text to convey the same information, then the success criterion is satisfied.
+[Understanding SC 1.4.5 Images of Text][understanding sc1.4.5] explicitly clarifies in its note that the success criterion is meant to address cases where images of text are used instead of actual text. If images of text are used in addition to real text to convey the same information, then the success criterion is satisfied.
 
 ### Assumptions
 
@@ -250,7 +247,7 @@ This `svg` element does not have `image` element descendants.
 [image button]: https://html.spec.whatwg.org/multipage/input.html#image-button-state-(type=image)
 [purely decorative]: https://www.w3.org/TR/WCAG22/#dfn-pure-decoration 'WCAG 2.2, Purely decorative'
 [rendered image resources]: #rendered-image-resource 'Definition of rendered image resource'
-[sc1.4.5]: https://www.w3.org/WAI/WCAG22/Understanding/images-of-text
+[understanding sc1.4.5]: https://www.w3.org/WAI/WCAG22/Understanding/images-of-text
 [sc1.4.9]: https://www.w3.org/WAI/WCAG22/Understanding/images-of-text-no-exception
 [visible]: #visible 'Definition of visible'
 [web page]: #web-page-html 'Definition of web page (HTML)'

--- a/_rules/image-no-text-0va7u6.md
+++ b/_rules/image-no-text-0va7u6.md
@@ -207,7 +207,7 @@ This image resource referenced by the `background-image` property of the `div` e
 <div style="background-image: url(/test-assets/0va7u6/textimage.jpg); width: 500px; height: 200px;" />
 ```
 
-#### Failed Example 5
+#### Failed Example 4
 
 This `img` element loads an SVG with text as an image resource. Because the SVG is loaded as an image resource, instead of being embedded in HTML the text cannot be selected or customized.
 

--- a/_rules/image-no-text-0va7u6.md
+++ b/_rules/image-no-text-0va7u6.md
@@ -247,7 +247,9 @@ This `svg` element does not have `image` element descendants.
 [image button]: https://html.spec.whatwg.org/multipage/input.html#image-button-state-(type=image)
 [purely decorative]: https://www.w3.org/TR/WCAG22/#dfn-pure-decoration 'WCAG 2.2, Purely decorative'
 [rendered image resources]: #rendered-image-resource 'Definition of rendered image resource'
+[sc1.4.5]: https://www.w3.org/TR/WCAG22/#images-of-text
 [understanding sc1.4.5]: https://www.w3.org/WAI/WCAG22/Understanding/images-of-text
-[sc1.4.9]: https://www.w3.org/WAI/WCAG22/Understanding/images-of-text-no-exception
+[sc1.4.9]: https://www.w3.org/TR/WCAG22/#images-of-text-no-exception
+[understanding sc1.4.9]: https://www.w3.org/WAI/WCAG22/Understanding/images-of-text-no-exception
 [visible]: #visible 'Definition of visible'
 [web page]: #web-page-html 'Definition of web page (HTML)'

--- a/_rules/image-no-text-0va7u6.md
+++ b/_rules/image-no-text-0va7u6.md
@@ -250,6 +250,5 @@ This `svg` element does not have `image` element descendants.
 [sc1.4.5]: https://www.w3.org/TR/WCAG22/#images-of-text
 [understanding sc1.4.5]: https://www.w3.org/WAI/WCAG22/Understanding/images-of-text
 [sc1.4.9]: https://www.w3.org/TR/WCAG22/#images-of-text-no-exception
-[understanding sc1.4.9]: https://www.w3.org/WAI/WCAG22/Understanding/images-of-text-no-exception
 [visible]: #visible 'Definition of visible'
 [web page]: #web-page-html 'Definition of web page (HTML)'


### PR DESCRIPTION
Closes issue(s): #2397

This PR moves failed example 4 to passing example 9, as SC 1.4.5 Images of Text clearly states in its note that when the same information conveyed by an image of text is also available as real text, the requirement is satisfied.

Need for Call for Review:
This will require a 1 week Call for Review 

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
