### PR TITLE
[kb1m8s] Failed example 5 does not fail the rule

### DIFF
--- a/_rules/aria-global-property-not-prohibited-kb1m8s.md
+++ b/_rules/aria-global-property-not-prohibited-kb1m8s.md
@@ -135,10 +135,10 @@ The `aria-roledescription` property is [prohibited][] for an element with a `gen
 
 #### Failed Example 5
 
-The `aria-brailleroledescription` property is [prohibited][] for an element with a `none` role.
+The `aria-brailleroledescription` property is [prohibited][] for an element with a `generic` role.
 
 ```html
-<h1 role="none" aria-brailleroledescription="Banana text">I like bananas</h1>
+<div aria-brailleroledescription="Banana text">I like bananas</div>
 ```
 
 ### Inapplicable


### PR DESCRIPTION
In [ARIA global properties not used where prohibited](https://www.w3.org/WAI/standards-guidelines/act/rules/kb1m8s/proposed/), [Failed example 5](https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/kb1m8s/c4a2fe12d5a48f7ace66475d3791e051ddefa807.html) does not violate the rule. [aria-brailleroledescription](https://w3c.github.io/aria/#aria-brailleroledescription) is not prohibited for elements with the `none` role, but it is prohibited for elements with the `generic` role, so I've updated the example by replacing "none" with "generic".

Closes issue(s): #2386 

Need for Call for Review:
This will require a 1 week Call for Review

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
