### PR TITLE
fix(label-in-name): remove SC-failing inapplicable examples

### DIFF
--- a/_rules/visible-label-in-accessible-name-2ee8b8.md
+++ b/_rules/visible-label-in-accessible-name-2ee8b8.md
@@ -401,22 +401,6 @@ This link has no [visible text content][].
 </a>
 ```
 
-#### Inapplicable Example 5
-
-This link's label contains an abbreviation.
-
-```html
-<a aria-label="University Avenue" href="#">University Ave.</a>
-```
-
-#### Inapplicable Example 6
-
-This word - non-standard / nonstandard - appears in both the element's accessible name and its visible label, using different hyphenation.
-
-```html
-<a href="#" aria-label="non-standard">nonstandard</a>
-```
-
 [accessible name]: #accessible-name 'Definition of accessible name'
 [label in name algorithm]: #label-in-name-algorithm 'Definition of Label in Name Algorithm'
 [non-text content]: https://www.w3.org/TR/WCAG22/#dfn-non-text-content 'WCAG Definition of Non-text content'


### PR DESCRIPTION
Removed inapplicable examples regarding abbreviations and non-standard terms from the document. These two may be inapplicable to the rule, but IMO they fail the success criterion. There is are no exceptions for abbreviations in this WCAG criterion. By having these as inapplicable examples we prohibit implementors from failing these.

Need for Call for Review: 1 week

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
